### PR TITLE
Implement support for handling OPTIONS message from client.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ pomExtra := {
 libraryDependencies ++= Seq(
   "com.typesafe.akka" % "akka-testkit_2.10" % akkaVersion % "test",
   "io.spray" % "spray-testkit" % sprayVersion % "test",
-  "com.datastax.cassandra" % "cassandra-driver-core" % "2.0.9" % "test" exclude("com.google.guava", "guava"),
+  "com.datastax.cassandra" % "cassandra-driver-core" % "2.0.10" % "test" exclude("com.google.guava", "guava"),
   "net.databinder.dispatch" %% "dispatch-core" % "0.11.0" % "test",
   "org.scalatest" %% "scalatest" % "2.2.3" % "test",
   "org.pegdown" % "pegdown" % "1.4.2", // added as a hack to get scala test html reports working, was getting a NoClassDef

--- a/src/main/scala/org/scassandra/server/actors/OptionsHandler.scala
+++ b/src/main/scala/org/scassandra/server/actors/OptionsHandler.scala
@@ -1,0 +1,23 @@
+package org.scassandra.server.actors
+
+import akka.actor.{ActorRef, Actor}
+import com.typesafe.scalalogging.slf4j.Logging
+import org.scassandra.server.cqlmessages.CqlMessageFactory
+
+class OptionsHandler(connection: ActorRef, msgFactory: CqlMessageFactory) extends Actor with Logging {
+  import org.scassandra.server.actors.OptionsHandlerMessages._
+
+  override def receive: Receive = {
+    case msg @ OptionsMessage(stream) => {
+      logger.debug(s"Received OPTIONS message $msg")
+      connection ! msgFactory.createSupportedMessage(stream)
+    }
+    case msg @ _ => {
+      logger.debug(s"Received unknown message $msg")
+    }
+  }
+}
+
+object OptionsHandlerMessages {
+  case class OptionsMessage(stream: Byte)
+}

--- a/src/main/scala/org/scassandra/server/actors/TcpServer.scala
+++ b/src/main/scala/org/scassandra/server/actors/TcpServer.scala
@@ -55,6 +55,7 @@ class TcpServer(listenAddress: String, port: Int,
       val handler = context.actorOf(Props(classOf[ConnectionHandler],
         (af: ActorRefFactory, sender: ActorRef, msgFactory: CqlMessageFactory) => af.actorOf(Props(classOf[QueryHandler], sender, primedResults, msgFactory, activityLog)),
         (af: ActorRefFactory, sender: ActorRef, msgFactory: CqlMessageFactory) => af.actorOf(Props(classOf[RegisterHandler], sender, msgFactory)),
+        (af: ActorRefFactory, sender: ActorRef, msgFactory: CqlMessageFactory) => af.actorOf(Props(classOf[OptionsHandler], sender, msgFactory)),
         preparedHandler,
         (af: ActorRefFactory, tcpConnection: ActorRef) => af.actorOf(Props(classOf[TcpConnectionWrapper], tcpConnection)))
       )

--- a/src/main/scala/org/scassandra/server/cqlmessages/AbstractMessageFactory.scala
+++ b/src/main/scala/org/scassandra/server/cqlmessages/AbstractMessageFactory.scala
@@ -69,6 +69,11 @@ abstract class AbstractMessageFactory extends CqlMessageFactory {
     UnavailableException(stream, consistency, unavailableResult)
   }
 
+  override def createSupportedMessage(stream: Byte): Supported = {
+    // TODO: If compression is ever supported include 'COMPRESSION' options.
+    Supported(stream)
+  }
+
   def createVoidMessage(stream: Byte): VoidResult = {
     VoidResult(stream)
   }

--- a/src/main/scala/org/scassandra/server/cqlmessages/CqlMessageFactory.scala
+++ b/src/main/scala/org/scassandra/server/cqlmessages/CqlMessageFactory.scala
@@ -33,6 +33,7 @@ trait CqlMessageFactory {
   def createUnavailableMessage(stream: Byte, consistency: Consistency, unavailableResult: UnavailableResult): UnavailableException
   def createVoidMessage(stream: Byte): VoidResult
   def createPreparedResult(stream: Byte, id: Int, variableTypes: List[ColumnType[_]]): Result
+  def createSupportedMessage(stream: Byte): Supported
 
   def parseExecuteRequestWithoutVariables(stream: Byte, byteString: ByteString): ExecuteRequest
   def parseExecuteRequestWithVariables(stream: Byte, byteString: ByteString, variableTypes: List[ColumnType[_]]): ExecuteRequest

--- a/src/main/scala/org/scassandra/server/cqlmessages/OpCodes.scala
+++ b/src/main/scala/org/scassandra/server/cqlmessages/OpCodes.scala
@@ -21,6 +21,7 @@ object OpCodes {
   val Startup: Byte = 0x01
   val Ready: Byte = 0x02
   val Options: Byte = 0x05
+  val Supported: Byte = 0x06
   val Query: Byte = 0x07
   val Result: Byte = 0x08
   val Prepare: Byte = 0x09

--- a/src/main/scala/org/scassandra/server/cqlmessages/request/Request.scala
+++ b/src/main/scala/org/scassandra/server/cqlmessages/request/Request.scala
@@ -32,9 +32,7 @@ object StartupRequest extends Request(StartupHeader) {
   override def serialize() = {
     val header = StartupHeader.serialize()
 
-    val body = CqlProtocolHelper.serializeShort(options.size.toShort) ++
-      CqlProtocolHelper.serializeString(options.head._1) ++
-      CqlProtocolHelper.serializeString(options.head._2)
+    val body = CqlProtocolHelper.serializeStringMap(options)
 
     ByteString((header ++ CqlProtocolHelper.serializeInt(body.size) ++ body))
   }

--- a/src/main/scala/org/scassandra/server/cqlmessages/response/Response.scala
+++ b/src/main/scala/org/scassandra/server/cqlmessages/response/Response.scala
@@ -38,3 +38,18 @@ case class Ready(stream : Byte = ResponseHeader.DefaultStreamId)(implicit protoc
     bs.result()
   }
 }
+
+case class Supported(stream : Byte = ResponseHeader.DefaultStreamId, map: Map[String,Set[String]] = Map("CQL_VERSION" -> Set("3.0.0")))(implicit protocolVersion: ProtocolVersion)
+  extends Response(new Header(protocolVersion.serverCode, opCode = OpCodes.Supported, streamId = stream)) {
+
+  implicit val byteOrder = java.nio.ByteOrder.BIG_ENDIAN
+
+  override def serialize() : ByteString = {
+    val bs = ByteString.newBuilder
+    bs.putBytes(header.serialize())
+    val mapBytes = CqlProtocolHelper.serializeStringMultiMap(map)
+    bs.putInt(mapBytes.size)
+    bs.putBytes(mapBytes)
+    bs.result()
+  }
+}

--- a/src/test/scala/org/scassandra/server/AbstractIntegrationTest.scala
+++ b/src/test/scala/org/scassandra/server/AbstractIntegrationTest.scala
@@ -126,7 +126,9 @@ abstract class AbstractIntegrationTest(clusterConnect: Boolean = true) extends F
   override def afterAll() {
     stopServerStub()
 
-    cluster.close()
+    if(cluster != null) {
+      cluster.close()
+    }
   }
 }
 

--- a/src/test/scala/org/scassandra/server/actors/MessageHelper.scala
+++ b/src/test/scala/org/scassandra/server/actors/MessageHelper.scala
@@ -80,6 +80,10 @@ object MessageHelper {
     numberOfOptions ::: singleOption
   }
 
+  def createOptionsMessage(protocolVersion : Byte = ProtocolVersion.ClientProtocolVersionTwo, stream : Byte = 0) : List[Byte] = {
+    List[Byte](protocolVersion, 0x00, stream, OpCodes.Options) ::: serializeInt(0)
+  }
+
 
   private def serializeLongString(string: String): List[Byte] = {
     serializeInt(string.length) :::

--- a/src/test/scala/org/scassandra/server/actors/OptionsHandlerTest.scala
+++ b/src/test/scala/org/scassandra/server/actors/OptionsHandlerTest.scala
@@ -1,0 +1,23 @@
+package org.scassandra.server.actors
+
+import akka.actor.ActorSystem
+import akka.testkit.{TestActorRef, TestProbe, TestKit}
+import org.scalatest.{FunSuiteLike, Matchers}
+import org.scassandra.server.cqlmessages.VersionTwoMessageFactory
+
+class OptionsHandlerTest extends TestKit(ActorSystem("TestSystem")) with FunSuiteLike with Matchers {
+
+  test("Should send supported message on any Options message") {
+    val senderTestProbe = TestProbe()
+    val cqlMessageFactory = VersionTwoMessageFactory
+    val stream : Byte = 0x24
+
+    val expectedSupportedMessage = cqlMessageFactory.createSupportedMessage(stream)
+    val underTest = TestActorRef(new OptionsHandler(senderTestProbe.ref, cqlMessageFactory))
+
+    underTest ! OptionsHandlerMessages.OptionsMessage(stream)
+
+    senderTestProbe.expectMsg(expectedSupportedMessage)
+  }
+
+}

--- a/src/test/scala/org/scassandra/server/cqlmessages/CqlProtocolHelperTest.scala
+++ b/src/test/scala/org/scassandra/server/cqlmessages/CqlProtocolHelperTest.scala
@@ -140,4 +140,64 @@ class CqlProtocolHelperTest extends FunSuite with Matchers {
 
     set.get should equal(Set("one", "two"))
   }
+
+  test("Serializing [string list] value - (1,22,333,4444,55555)") {
+    val list = List("1","22","333","4444","55555")
+    val listAsBytes = CqlProtocolHelper.serializeStringList(list)
+    listAsBytes should equal(Array[Byte](0x00, 0x5,
+      0x00, 0x01, 0x31,
+      0x00, 0x02, 0x32, 0x32,
+      0x00, 0x03, 0x33, 0x33, 0x33,
+      0x00, 0x04, 0x34, 0x34, 0x34, 0x34,
+      0x00, 0x05, 0x35, 0x35, 0x35, 0x35, 0x35))
+  }
+
+  test("Serializing [string map] value - (1 -> 2, 3 -> 4, 5 -> 6)") {
+    val map = Map("1" -> "2", "3" -> "4", "5" -> "6")
+    val mapAsBytes = CqlProtocolHelper.serializeStringMap(map)
+
+    val (lengthBytes, dataBytes) = mapAsBytes.splitAt(2)
+
+    lengthBytes should equal(Array[Byte](0x00, 0x03))
+
+    dataBytes.grouped(6).toList should contain only
+      (Array[Byte](0x00, 0x01, 0x31, 0x00, 0x01, 0x32),
+      Array[Byte](0x00, 0x01, 0x33, 0x00, 0x01, 0x34),
+      Array[Byte](0x00, 0x01, 0x35, 0x00, 0x01, 0x36))
+  }
+
+  test("Serializing [string multimap] value - (1 -> [2], 3 -> [4, 5], 6 -> [7, 8, 9])") {
+    val map = Map("1" -> Set("2"), "3" -> Set("4", "5"), "6" -> Set("7", "8", "9"))
+    val mapAsBytes = CqlProtocolHelper.serializeStringMultiMap(map)
+
+    val (lengthBytes, dataBytes) = mapAsBytes.splitAt(2)
+
+    lengthBytes should equal(Array[Byte](0x00, 0x03))
+
+    def matchesExpected(remaining: Array[Byte]): Unit = remaining match {
+      case x if x.size == 0 => ()
+      case _ =>
+        val (lengthBytes, remainingBytes) = remaining.splitAt(2)
+        lengthBytes should equal(Array[Byte](0x00, 0x01))
+        val (keyBytes, remainingBytes2) = remainingBytes.splitAt(1)
+        keyBytes(0) match {
+          case 0x31      =>
+            val (bytes, remainingBytes3) = remainingBytes2.splitAt(5)
+            bytes should equal (Array[Byte](0x00, 0x01, 0x00, 0x01, 0x32))
+            matchesExpected(remainingBytes3)
+          case 0x33      =>
+            val (bytes, remainingBytes3) = remainingBytes2.splitAt(8)
+            bytes should equal (Array[Byte](0x00, 0x02, 0x00, 0x01, 0x34, 0x00, 0x01, 0x35))
+            matchesExpected(remainingBytes3)
+          case 0x36      =>
+            val (bytes, remainingBytes3) = remainingBytes2.splitAt(11)
+            bytes should equal (Array[Byte](0x00, 0x03, 0x00, 0x01, 0x37, 0x00, 0x01, 0x38, 0x00, 0x01, 0x39))
+            matchesExpected(remainingBytes3)
+          case value @ _ => fail(s"Unexpected value $value")
+        }
+    }
+
+    matchesExpected(dataBytes)
+  }
+
 }

--- a/src/test/scala/org/scassandra/server/e2e/ConnectionVerificationTest.scala
+++ b/src/test/scala/org/scassandra/server/e2e/ConnectionVerificationTest.scala
@@ -50,9 +50,11 @@ class ConnectionVerificationTest extends AbstractIntegrationTest with ScalaFutur
     whenReady(response) {
       result =>
         val connectionList = JsonParser(result).convertTo[List[Connection]]
-        // What ever the pooling options are set to the java driver appears to make 3 connections
-        // verified with wireshark
-        connectionList.size should equal(9)
+        // The java driver establishes 1 control + core connections.
+        connectionList.size should equal(1 + cluster
+          .getConfiguration
+          .getPoolingOptions
+          .getCoreConnectionsPerHost(HostDistance.LOCAL))
     }
   }
 

--- a/src/test/scala/org/scassandra/server/e2e/HeartbeatVerificationTest.scala
+++ b/src/test/scala/org/scassandra/server/e2e/HeartbeatVerificationTest.scala
@@ -1,0 +1,33 @@
+package org.scassandra.server.e2e
+
+import com.datastax.driver.core.policies.ConstantReconnectionPolicy
+import com.datastax.driver.core.{HostDistance, PoolingOptions, Cluster, SocketOptions}
+import org.scassandra.server.{ConnectionToServerStub, AbstractIntegrationTest}
+
+class HeartbeatVerificationTest extends AbstractIntegrationTest(false) {
+
+  test("Should remain connected after heartbeat interval + read timeout.") {
+    // Configures a cluster with a heartbeat interval of 1 second, a read timeout
+    // of 2 seconds (to provoke quick heartbeat timeouts), and a reconnection
+    // timeout of 60 seconds to delay reconnection.
+    val cluster = Cluster.builder()
+      .addContactPoint(ConnectionToServerStub.ServerHost)
+      .withPort(ConnectionToServerStub.ServerPort)
+      .withPoolingOptions(new PoolingOptions()
+        .setCoreConnectionsPerHost(HostDistance.LOCAL, 1)
+        .setHeartbeatIntervalSeconds(1))
+      .withSocketOptions(new SocketOptions().setReadTimeoutMillis(2000))
+      .withReconnectionPolicy(new ConstantReconnectionPolicy(60000))
+      .build()
+    try {
+      val session = cluster.connect()
+
+      // Wait for some time after heartbeat interval + read timeout and
+      // ensure that we are still connected.
+      Thread.sleep(5000)
+      session.getState.getConnectedHosts.size() should equal(1)
+    } finally {
+      cluster.close()
+    }
+  }
+}


### PR DESCRIPTION
Hello!  On the drivers team at DataStax, we are very interested in Scassandra and are beginning to pursue using it in our testing as it makes it much easier to test certain scenarios (i.e. timeouts, delays, certain exceptional conditions) then using a live cassandra instance.  While playing around with Scassandra I noticed that occasionally my clients would lose connection to a Scassandra instance.  This happened to have been caused by a recent unreleased change to java-driver.

All DataStax drivers have added or are in the process of adding a 'heartbeat' feature that sends an 'OPTIONS' message on a predefined interval to keep connections opened that may be timed out by ISPs or intermediate networking equipment that times out idle connections.  If a 'SUPPORTED' message is not sent in response within the driver's configured read timeout, the connection is closed and must be re-established.

The java driver will be implementing this feature in 2.0.10 and 2.1.5 (via [JAVA-533](https://datastax-oss.atlassian.net/browse/JAVA-533)) with a default idle time of 30 seconds.

I went ahead and implemented support for handling Options messages in Scassandra.  I also added some helper methods in CqlProtocolHelper for serializing & deserializing [string list], [string map], and [string multimap], which I afterwards realized may duplicate some functionality from CqlMap, CqlSet, and CqlList, but thought it could still be useful to break this functionality out into helper methods.