### PR TITLE
Migrate to container-based infrastructure for travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ jdk:
   - oraclejdk8
 scala:
   - 2.11.6
+sudo: false
 
 install: ./gradlew assemble -x signArchives
 script: ./gradlew  check -x signArchives


### PR DESCRIPTION
Adding 'sudo: false' enables builds in a container.  See: http://docs.travis-ci.com/user/migrating-from-legacy/ for benefits of container-based builds.

