### PR TITLE
Change SelectionPath to ActorSelectionMessage

### DIFF
--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -721,7 +721,7 @@ akka {
       # Since com.google.protobuf.Message does not extend Serializable but
       # GeneratedMessage does, need to use the more specific one here in order
       # to avoid ambiguity
-      "akka.actor.SelectionPath" = akka-containers
+      "akka.actor.ActorSelectionMessage" = akka-containers
       "com.google.protobuf.GeneratedMessage" = proto
       "akka.remote.DaemonMsgCreate" = daemon-create
     }

--- a/server/src/test/resources/reference.conf
+++ b/server/src/test/resources/reference.conf
@@ -721,7 +721,7 @@ akka {
       # Since com.google.protobuf.Message does not extend Serializable but
       # GeneratedMessage does, need to use the more specific one here in order
       # to avoid ambiguity
-      "akka.actor.SelectionPath" = akka-containers
+      "akka.actor.ActorSelectionMessage" = akka-containers
       "com.google.protobuf.GeneratedMessage" = proto
       "akka.remote.DaemonMsgCreate" = daemon-create
     }


### PR DESCRIPTION
This fixes #109.  Updating from akka.actor.SelectionPath to akka.actor.ActorSelectionMessage, to reflect the reference.conf section in recent versions of akka-remote.