### PR TITLE
[#112] Add 'closed_connection' prime result.

### DIFF
--- a/docs/standalone/priming-ps.md
+++ b/docs/standalone/priming-ps.md
@@ -82,6 +82,19 @@ Where result can be:
 read_request_timeout
 write_request_timeout
 unavailable
+server_error
+protocol_error
+bad_credentials
+overloaded
+is_bootstrapping
+truncate_error
+syntax_error
+unauthorized
+invalid
+config_error
+already_exists
+unprepared
+closed_connection
 ```
 
 #### Seeing your existing primes

--- a/docs/standalone/priming-query.md
+++ b/docs/standalone/priming-query.md
@@ -55,6 +55,19 @@ Where result can be:
 read_request_timeout
 write_request_timeout
 unavailable
+server_error
+protocol_error
+bad_credentials
+overloaded
+is_bootstrapping
+truncate_error
+syntax_error
+unauthorized
+invalid
+config_error
+already_exists
+unprepared
+closed_connection
 ```
 
 

--- a/java-client/src/main/java/org/scassandra/http/client/ClosedConnectionConfig.java
+++ b/java-client/src/main/java/org/scassandra/http/client/ClosedConnectionConfig.java
@@ -1,0 +1,28 @@
+package org.scassandra.http.client;
+
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import org.scassandra.server.priming.ErrorConstants;
+
+public class ClosedConnectionConfig extends Config {
+
+    public enum CloseType {
+        CLOSE,
+        RESET,
+        HALFCLOSE;
+    }
+
+    private final CloseType closeType;
+
+    public ClosedConnectionConfig(CloseType closeType) {
+        this.closeType = closeType;
+    }
+
+    @Override
+    Map<String, ?> getProperties() {
+        return ImmutableMap.of(
+            ErrorConstants.CloseType(), String.valueOf(closeType.toString().toLowerCase())
+        );
+    }
+}

--- a/java-client/src/main/java/org/scassandra/http/client/PrimingRequest.java
+++ b/java-client/src/main/java/org/scassandra/http/client/PrimingRequest.java
@@ -500,7 +500,8 @@ public final class PrimingRequest {
         invalid,
         config_error,
         already_exists,
-        unprepared
+        unprepared,
+        closed_connection
     }
 
 }

--- a/java-it-tests/driver20/src/test/java/cassandra/CassandraExecutor20.java
+++ b/java-it-tests/driver20/src/test/java/cassandra/CassandraExecutor20.java
@@ -127,7 +127,7 @@ public class CassandraExecutor20 implements CassandraExecutor {
                             e.getAliveReplicas()));
         } catch (NoHostAvailableException e) {
             PrimingRequest.Result error = server_error;
-            String message = "";
+            String message = e.getMessage();
             InetSocketAddress addr = e.getErrors().keySet().iterator().next();
             Throwable e1 = e.getErrors().get(addr);
             try {

--- a/java-it-tests/driver21/src/test/java/cassandra/CassandraExecutor21.java
+++ b/java-it-tests/driver21/src/test/java/cassandra/CassandraExecutor21.java
@@ -128,7 +128,7 @@ public class CassandraExecutor21 implements CassandraExecutor {
                             e.getAliveReplicas()));
         } catch (NoHostAvailableException e) {
             PrimingRequest.Result error = server_error;
-            String message = "";
+            String message = e.getMessage();
             InetSocketAddress addr = e.getErrors().keySet().iterator().next();
             Throwable e1 = e.getErrors().get(addr);
             try {

--- a/java-it-tests/driver30/src/test/java/cassandra/CassandraExecutor30.java
+++ b/java-it-tests/driver30/src/test/java/cassandra/CassandraExecutor30.java
@@ -131,7 +131,7 @@ public class CassandraExecutor30 implements CassandraExecutor {
                             e.getAliveReplicas()));
         } catch (NoHostAvailableException e) {
             PrimingRequest.Result error = server_error;
-            String message = "";
+            String message = e.getMessage();
             InetSocketAddress addr = e.getErrors().keySet().iterator().next();
             Throwable e1 = e.getErrors().get(addr);
             try {

--- a/server/src/main/scala/org/scassandra/server/actors/BatchHandler.scala
+++ b/server/src/main/scala/org/scassandra/server/actors/BatchHandler.scala
@@ -104,6 +104,7 @@ class BatchHandler(tcpConnection: ActorRef,
     prime match {
       case Some(BatchPrime(SuccessResult)) => tcpConnection ! msgFactory.createVoidMessage(stream)
       case Some(BatchPrime(errorResult: ErrorResult)) => tcpConnection ! msgFactory.createErrorMessage(errorResult, stream, consistency)
+      case Some(BatchPrime(fatalResult: FatalResult)) => fatalResult.produceFatalError(tcpConnection)
       case None => tcpConnection ! msgFactory.createVoidMessage(stream)
     }
   }

--- a/server/src/main/scala/org/scassandra/server/actors/QueryHandler.scala
+++ b/server/src/main/scala/org/scassandra/server/actors/QueryHandler.scala
@@ -50,6 +50,7 @@ class QueryHandler(tcpConnection: ActorRef, primeQueryStore: PrimeQueryStore, ms
                 log.info(s"Found matching prime $prime for query $queryText")
                 msgFactory.createRowsMessage(prime, stream)
               case result: ErrorResult => msgFactory.createErrorMessage(result, stream, consistency)
+              case result: FatalResult => result.produceFatalError(tcpConnection)
             }
             sendMessage(prime.fixedDelay, tcpConnection, message)
             val queryRequest = msgFactory.parseQueryRequest(stream, queryBody, prime.variableTypes)

--- a/server/src/main/scala/org/scassandra/server/priming/ErrorConstants.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/ErrorConstants.scala
@@ -25,4 +25,5 @@ object ErrorConstants {
   var Table = "error.table"
   val Message = "error.message"
   var PrepareId = "error.prepare_id"
+  var CloseType = "error.close_type"
 }

--- a/server/src/main/scala/org/scassandra/server/priming/json/ResultJsonRepresentation.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/json/ResultJsonRepresentation.scala
@@ -52,6 +52,8 @@ case object AlreadyExists extends ResultJsonRepresentation("already_exists")
 
 case object Unprepared extends ResultJsonRepresentation("unprepared")
 
+case object ClosedConnection extends ResultJsonRepresentation("closed_connection")
+
 object ResultJsonRepresentation {
   def fromString(string: String): ResultJsonRepresentation = {
     string match {
@@ -70,6 +72,7 @@ object ResultJsonRepresentation {
       case ConfigError.string => ConfigError
       case AlreadyExists.string => AlreadyExists
       case Unprepared.string => Unprepared
+      case ClosedConnection.string => ClosedConnection
       case Success.string => Success
       case _ => Success
     }

--- a/server/src/main/scala/org/scassandra/server/priming/routes/PrimeQueryResultExtractor.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/routes/PrimeQueryResultExtractor.scala
@@ -118,6 +118,10 @@ object PrimeQueryResultExtractor extends LazyLogging {
       case Unavailable => UnavailableResult(
         config.getOrElse(ErrorConstants.RequiredResponse, "1").toInt,
         config.getOrElse(ErrorConstants.Alive, "0").toInt)
+
+      case ClosedConnection => ClosedConnectionResult(
+        config.getOrElse(ErrorConstants.CloseType, "close")
+      )
     }
     primeResult
   }
@@ -143,6 +147,7 @@ object PrimeQueryResultExtractor extends LazyLogging {
         case _: ConfigErrorResult => ConfigError
         case _: AlreadyExistsResult => AlreadyExists
         case _: UnpreparedResult => Unprepared
+        case _: ClosedConnectionResult => ClosedConnection
       }
 
       val thenDo = Then(Some(prime.rows), result = Some(result), column_types = Some(prime.columnTypes))

--- a/server/src/main/scala/org/scassandra/server/priming/routes/PrimingPreparedRoute.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/routes/PrimingPreparedRoute.scala
@@ -84,6 +84,7 @@ trait PrimingPreparedRoute extends HttpService with LazyLogging {
               case _: ConfigErrorResult => ConfigError
               case _: AlreadyExistsResult => AlreadyExists
               case _: UnpreparedResult => Unprepared
+              case _: ClosedConnectionResult => ClosedConnection
             }
             PrimePreparedSingle(
               WhenPreparedSingle(

--- a/server/src/test/scala/org/scassandra/server/JavaDriverIntegrationTest.scala
+++ b/server/src/test/scala/org/scassandra/server/JavaDriverIntegrationTest.scala
@@ -141,4 +141,8 @@ class JavaDriverIntegrationTest extends AbstractIntegrationTest with ScalaFuture
   test("Test unprepared on query") {
     expectException[DriverInternalError](Unprepared, Some(Map(ErrorConstants.PrepareId -> "0x8675")))
   }
+
+  test("Test closed connection on query") {
+    expectException[NoHostAvailableException](ClosedConnection, Some(Map(ErrorConstants.CloseType -> "close")))
+  }
 }

--- a/server/src/test/scala/org/scassandra/server/actors/FatalHandlingBehaviors.scala
+++ b/server/src/test/scala/org/scassandra/server/actors/FatalHandlingBehaviors.scala
@@ -1,0 +1,27 @@
+package org.scassandra.server.actors
+
+import akka.io.Tcp
+import org.scalatest.FunSuite
+import org.scassandra.server.cqlmessages.ProtocolProvider
+import org.scassandra.server.priming.{ClosedConnectionResult, FatalResult}
+
+trait FatalHandlingBehaviors extends ProtocolProvider {
+  this: FunSuite =>
+
+  def executeWithFatal(result: FatalResult, expectedCommand: Tcp.CloseCommand)
+
+  test("Execute with ClosedCommand - close") {
+    val result = ClosedConnectionResult("close")
+    executeWithFatal(result, Tcp.Close)
+  }
+
+  test("Execute with ClosedCommand - reset") {
+    val result = ClosedConnectionResult("reset")
+    executeWithFatal(result, Tcp.Abort)
+  }
+
+  test("Execute with ClosedCommand - halfclose") {
+    val result = ClosedConnectionResult("halfclose")
+    executeWithFatal(result, Tcp.ConfirmedClose)
+  }
+}


### PR DESCRIPTION
Allows closing connections as a result of a request being received.  Can choose to reset/close/halfclose connection (similar to DELETE on /current/connections)

```json
{
  "when":{
    "query":"select * from people"
  },
  "then":{
    "result":"closed_connection",
    "config":{
      "error.close_type":"reset"
    }
  }
}
```