### PR TITLE
Adds support for statically typed insert statements.

### DIFF
--- a/server/src/main/scala/org/scassandra/server/actors/ExecuteHandler.scala
+++ b/server/src/main/scala/org/scassandra/server/actors/ExecuteHandler.scala
@@ -41,9 +41,10 @@ class ExecuteHandler(primePreparedStore: PreparedStoreLookup, activityLog: Activ
       case Some(p) =>
         val matchingPrimedAction = for {
           prime <- primePreparedStore.findPrime(PrimeMatch(p, executeRequest.consistency))
-          if executeRequest.numberOfVariables == prime.variableTypes.size
-          parsed = msgFactory.parseExecuteRequestWithVariables(stream, body, prime.variableTypes)
-          pse = PreparedStatementExecution(p, parsed.consistency, parsed.variables, prime.variableTypes)
+          if executeRequest.numberOfVariables == prime.variableTypes.size || executeRequest.numberOfVariables == prime.prime.columnTypes.size
+          columnTypes = if (executeRequest.numberOfVariables == prime.variableTypes.size) prime.variableTypes else prime.prime.columnTypes.values.toList
+          parsed = msgFactory.parseExecuteRequestWithVariables(stream, body, columnTypes)
+          pse = PreparedStatementExecution(p, parsed.consistency, parsed.variables, columnTypes)
         } yield ExecuteResponse(Some(pse), MessageWithDelay(createMessage(prime, executeRequest, stream, msgFactory, connection), prime.prime.fixedDelay))
 
         lazy val defaultAction = ExecuteResponse(Some(PreparedStatementExecution(p, executeRequest.consistency, List(), List())),

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/CqlMessageFactory.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/CqlMessageFactory.scala
@@ -50,7 +50,7 @@ trait CqlMessageFactory {
   def createAlreadyExistsMessage(stream: Byte, alreadyExistsResult: AlreadyExistsResult): AlreadyExists
   def createdUnpreparedMessage(stream: Byte, unpreparedResult: UnpreparedResult): Unprepared
   def createVoidMessage(stream: Byte): VoidResult
-  def createPreparedResult(stream: Byte, id: Int, variableTypes: List[ColumnType[_]]): Result
+  def createPreparedResult(stream: Byte, id: Int, variableTypes: List[ColumnType[_]], columns: Map[String, ColumnType[_]]): Result
   def createSupportedMessage(stream: Byte): Supported
 
   def parseExecuteRequestWithoutVariables(stream: Byte, byteString: ByteString): ExecuteRequest

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/CqlMessageFactory.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/CqlMessageFactory.scala
@@ -55,6 +55,7 @@ trait CqlMessageFactory {
 
   def parseExecuteRequestWithoutVariables(stream: Byte, byteString: ByteString): ExecuteRequest
   def parseExecuteRequestWithVariables(stream: Byte, byteString: ByteString, variableTypes: List[ColumnType[_]]): ExecuteRequest
+  def parseExecuteRequestWithColumnTypes(stream: Byte, byteString: ByteString, columnTypes: Map[String, ColumnType[_]]): ExecuteRequest
 
   def parseQueryRequest(stream: Byte, byteString: ByteString, variableTypes: List[ColumnType[_]]): QueryRequest
 

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/VersionOneMessageFactory.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/VersionOneMessageFactory.scala
@@ -37,6 +37,10 @@ object VersionOneMessageFactory extends AbstractMessageFactory {
     ExecuteRequest.versionOneWithTypes(stream, byteString, variableTypes)
   }
 
+  def parseExecuteRequestWithColumnTypes(stream: Byte, byteString: ByteString, columnTypes: Map[String, ColumnType[_]]): ExecuteRequest = {
+    ExecuteRequest.versionTwoWithTypes(stream, byteString, columnTypes.values.toList)
+  }
+
   def parseBatchQuery(byteString: ByteIterator): String  = throw new UnsupportedOperationException("Batches not supported at v1 of the protocol")
 
   def readVariables(iterator: ByteIterator): List[Array[Byte]] = throw new UnsupportedOperationException("Batches not supported at v1 of the protocol")

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/VersionOneMessageFactory.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/VersionOneMessageFactory.scala
@@ -25,7 +25,7 @@ object VersionOneMessageFactory extends AbstractMessageFactory {
   implicit val protocolVersion = VersionOne
   import CqlProtocolHelper._
 
-  def createPreparedResult(stream: Byte, id : Int, variableTypes: List[ColumnType[_]]): PreparedResultV1 = {
+  def createPreparedResult(stream: Byte, id : Int, variableTypes: List[ColumnType[_]], columns: Map[String, ColumnType[_]]): PreparedResultV1 = {
     PreparedResultV1(stream, id, "keyspace", "table", variableTypes)
   }
 

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/VersionTwoMessageFactory.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/VersionTwoMessageFactory.scala
@@ -41,6 +41,10 @@ object VersionTwoMessageFactory extends AbstractMessageFactory {
     ExecuteRequest.versionTwoWithTypes(stream, byteString, variableTypes)
   }
 
+  def parseExecuteRequestWithColumnTypes(stream: Byte, byteString: ByteString, columnTypes: Map[String, ColumnType[_]]): ExecuteRequest = {
+    ExecuteRequest.versionTwoWithTypes(stream, byteString, columnTypes.values.toList)
+  }
+
   def parseBatchQuery(iterator: ByteIterator): String = {
     val query: String = readLongString(iterator).get
     val numVariables = iterator.getShort

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/VersionTwoMessageFactory.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/VersionTwoMessageFactory.scala
@@ -29,8 +29,8 @@ object VersionTwoMessageFactory extends AbstractMessageFactory {
 
   implicit val protocolVersion = VersionTwo
 
-  def createPreparedResult(stream: Byte, id : Int, variableTypes: List[ColumnType[_]]) = {
-    PreparedResultV2(stream, id, "keyspace", "table", variableTypes)
+  def createPreparedResult(stream: Byte, id : Int, variableTypes: List[ColumnType[_]], columns: Map[String, ColumnType[_]]) = {
+    PreparedResultV2(stream, id, "keyspace", "table", variableTypes, columns)
   }
 
   def parseExecuteRequestWithoutVariables(stream: Byte, byteString: ByteString): ExecuteRequest = {

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/response/PreparedResult.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/response/PreparedResult.scala
@@ -61,19 +61,23 @@ case class PreparedResultV2(stream: Byte, preparedStatementId: Int, keyspaceName
     bodyBs.putInt(preparedStatementId)
 
     bodyBs.putInt(1) // flags
-    bodyBs.putInt(variableTypes.size + columns.size) // col count
+    if (variableTypes.nonEmpty)
+      bodyBs.putInt(variableTypes.size)
+    else
+      bodyBs.putInt(columns.size)
 
     bodyBs.putBytes(serializeString(keyspaceName).toArray)
     bodyBs.putBytes(serializeString(tableName).toArray)
 
     // column specs
-    for (i <- 0 until variableTypes.length) {
-      ResultHelper.serialiseTypeInfomration(i.toString, variableTypes(i), bodyBs)
-    }
-
-    columns.foreach { case (columnName: String, columnType: ColumnType[_]) =>
-      ResultHelper.serialiseTypeInfomration(columnName, columnType, bodyBs)
-    }
+    if (variableTypes.nonEmpty)
+      for (i <- 0 until variableTypes.length) {
+        ResultHelper.serialiseTypeInfomration(i.toString, variableTypes(i), bodyBs)
+      }
+    else
+      columns.foreach { case (columnName: String, columnType: ColumnType[_]) =>
+        ResultHelper.serialiseTypeInfomration(columnName, columnType, bodyBs)
+      }
 
     // second meta data - 3 indicates it does not exist
     bodyBs.putInt(RowsFlags.HasNoMetaData)

--- a/server/src/test/scala/org/scassandra/server/AbstractIntegrationTest.scala
+++ b/server/src/test/scala/org/scassandra/server/AbstractIntegrationTest.scala
@@ -83,6 +83,11 @@ object PrimingHelper {
     JsonParser(body).convertTo[List[BatchExecution]]
   }
 
+  def clearRecordedPreparedStatements() = {
+    val svc = url(s"${DefaultHost}prepared-statement-execution").DELETE
+    Http(svc OK as.String)(dispatch.Defaults.executor)()
+  }
+
   def clearQueryPrimes(): String = {
     val svc = url(s"${DefaultHost}prime-query-single").DELETE
     Http(svc OK as.String)(dispatch.Defaults.executor)()

--- a/server/src/test/scala/org/scassandra/server/actors/PrepareHandlerTest.scala
+++ b/server/src/test/scala/org/scassandra/server/actors/PrepareHandlerTest.scala
@@ -85,7 +85,7 @@ class PrepareHandlerTest extends FunSuite with Matchers with TestKitBase with Be
 
     underTest ! PrepareHandler.Prepare(prepareBody, stream, versionTwoMessageFactory, testProbeForTcpConnection.ref)
 
-    testProbeForTcpConnection.expectMsg(PreparedResultV2(stream, 1.toShort, "keyspace", "table", List()))
+    testProbeForTcpConnection.expectMsg(PreparedResultV2(stream, 1.toShort, "keyspace", "table", List(), Map()))
   }
 
   test("Should return  prepared message on prepare - single param") {
@@ -95,7 +95,7 @@ class PrepareHandlerTest extends FunSuite with Matchers with TestKitBase with Be
 
     underTest ! PrepareHandler.Prepare(prepareBody, stream, versionTwoMessageFactory, testProbeForTcpConnection.ref)
 
-    testProbeForTcpConnection.expectMsg(PreparedResultV2(stream, 1.toShort, "keyspace", "table", List(CqlVarchar)))
+    testProbeForTcpConnection.expectMsg(PreparedResultV2(stream, 1.toShort, "keyspace", "table", List(CqlVarchar), Map()))
   }
 
   test("Priming variable types - Should use types from PreparedPrime") {
@@ -108,7 +108,7 @@ class PrepareHandlerTest extends FunSuite with Matchers with TestKitBase with Be
     underTest ! PrepareHandler.Prepare(prepareBody, stream, versionTwoMessageFactory, testProbeForTcpConnection.ref)
 
     verify(primePreparedStore).findPrime(PrimeMatch(query))
-    testProbeForTcpConnection.expectMsg(PreparedResultV2(stream, 1.toShort, "keyspace", "table", primedVariableTypes))
+    testProbeForTcpConnection.expectMsg(PreparedResultV2(stream, 1.toShort, "keyspace", "table", primedVariableTypes, Map()))
   }
 
   //todo may as well make these UUIDs
@@ -118,14 +118,14 @@ class PrepareHandlerTest extends FunSuite with Matchers with TestKitBase with Be
     val queryOne = "select * from something where name = ?"
     val prepareBodyOne: ByteString = PrepareRequest(protocolByte, stream, queryOne).serialize().drop(8)
     underTest ! PrepareHandler.Prepare(prepareBodyOne, stream, versionTwoMessageFactory, testProbeForTcpConnection.ref)
-    testProbeForTcpConnection.expectMsg(PreparedResultV2(stream, 1.toShort, "keyspace", "table", List(CqlVarchar)))
+    testProbeForTcpConnection.expectMsg(PreparedResultV2(stream, 1.toShort, "keyspace", "table", List(CqlVarchar), Map()))
 
     emptyTestProbe
 
     val queryTwo = "select * from something where name = ? and age = ?"
     val prepareBodyTwo: ByteString = PrepareRequest(protocolByte, stream, queryTwo).serialize().drop(8)
     underTest ! PrepareHandler.Prepare(prepareBodyTwo, stream, versionTwoMessageFactory, testProbeForTcpConnection.ref)
-    testProbeForTcpConnection.expectMsg(PreparedResultV2(stream, 2.toShort, "keyspace", "table", List(CqlVarchar, CqlVarchar)))
+    testProbeForTcpConnection.expectMsg(PreparedResultV2(stream, 2.toShort, "keyspace", "table", List(CqlVarchar, CqlVarchar), Map()))
 
   }
 
@@ -150,7 +150,7 @@ class PrepareHandlerTest extends FunSuite with Matchers with TestKitBase with Be
   private def sendPrepareAndCaptureId(stream: Byte, query: String, variableTypes: List[ColumnType[_]] = List(CqlVarchar)) : Int = {
     val prepareBodyOne: ByteString = PrepareRequest(protocolByte, stream, query).serialize().drop(8)
     underTest ! PrepareHandler.Prepare(prepareBodyOne, stream, versionTwoMessageFactory , testProbeForTcpConnection.ref)
-    val preparedResponseWithId: PreparedResultV2 = testProbeForTcpConnection.expectMsg(PreparedResultV2(stream, 1.toShort, "keyspace", "table", variableTypes))
+    val preparedResponseWithId: PreparedResultV2 = testProbeForTcpConnection.expectMsg(PreparedResultV2(stream, 1.toShort, "keyspace", "table", variableTypes, Map()))
     reset(primePreparedStore)
     when(primePreparedStore.findPrime(any(classOf[PrimeMatch]))).thenReturn(None)
     preparedResponseWithId.preparedStatementId

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/response/PreparedResultTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/response/PreparedResultTest.scala
@@ -18,7 +18,7 @@ package org.scassandra.server.cqlmessages.response
 import org.scassandra.server.cqlmessages.{VersionTwo, OpCodes}
 import org.scalatest.{Matchers, FunSuite}
 import org.scassandra.server.cqlmessages.CqlProtocolHelper._
-import org.scassandra.server.cqlmessages.types.CqlVarint
+import org.scassandra.server.cqlmessages.types.{ColumnType, CqlVarint}
 
 class PreparedResultTest extends FunSuite with Matchers {
 
@@ -70,7 +70,8 @@ class PreparedResultTest extends FunSuite with Matchers {
     val keyspace : String = "keyspace"
     val table : String = "table"
     val variableTypes = List(CqlVarint)
-    val preparedResult = PreparedResultV2(stream, preparedStatementId, keyspace, table, variableTypes)
+    val columns = Map[String, ColumnType[_]]()
+    val preparedResult = PreparedResultV2(stream, preparedStatementId, keyspace, table, variableTypes, columns)
     val bytes = preparedResult.serialize().iterator
 
     bytes.getByte should equal(protocolVersion.serverCode)

--- a/server/src/test/scala/org/scassandra/server/e2e/prepared/PreparedStatementsTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/prepared/PreparedStatementsTest.scala
@@ -20,7 +20,6 @@ import org.scassandra.server.priming.json.PrimingJsonImplicits
 import org.scassandra.server.{PrimingHelper, AbstractIntegrationTest}
 import org.scassandra.server.cqlmessages._
 import org.scassandra.server.priming.prepared.{PrimePreparedSingle, ThenPreparedSingle, WhenPreparedSingle}
-import scala.Some
 import java.nio.ByteBuffer
 import akka.util.ByteString
 import java.util.{UUID, Date}
@@ -28,13 +27,12 @@ import com.datastax.driver.core.utils.UUIDs
 import java.net.InetAddress
 import java.util
 import com.datastax.driver.core.{BoundStatement, ConsistencyLevel, Row}
-import org.scassandra.server.priming._
 import com.datastax.driver.core.exceptions.{UnavailableException, WriteTimeoutException, ReadTimeoutException}
 import org.scalatest.BeforeAndAfter
 import dispatch._, Defaults._
 import spray.json._
 import org.scassandra.server.cqlmessages.types._
-import org.scassandra.server.priming.ConflictingPrimes
+import org.scassandra.server.priming.{PreparedStatementExecution, ConflictingPrimes}
 import org.scassandra.server.priming.prepared.ThenPreparedSingle
 import org.scassandra.server.priming.prepared.WhenPreparedSingle
 import org.scassandra.server.priming.prepared.PrimePreparedSingle
@@ -165,7 +163,7 @@ class PreparedStatementsTest extends AbstractIntegrationTest with BeforeAndAfter
     results.size() should equal(1)
     results.get(0).getString("name") should equal("Chris")
   }
-  
+
   test("Conflicting primes") {
     //given
     val preparedStatementText = "select * from people where name = ?"
@@ -308,14 +306,16 @@ class PreparedStatementsTest extends AbstractIntegrationTest with BeforeAndAfter
   }
 
   test("prime insert with column types") {
+    //given
+    PrimingHelper.clearRecordedPreparedStatements()
     val preparedStatementText: String = "insert into people (age)"
     PrimingHelper.primePreparedStatement(
       WhenPreparedSingle(Some(preparedStatementText)),
-      ThenPreparedSingle(Some(List()), column_types = Some(Map("name"->CqlBigint)))
+      ThenPreparedSingle(Some(List()), column_types = Some(Map("age"->CqlBigint)))
     )
 
     val preparedStatement = session.prepare(preparedStatementText)
-    val boundStatement = new BoundStatement(preparedStatement).setLong("name", 10)
+    val boundStatement = new BoundStatement(preparedStatement).setLong("age", 10)
 
     //when
     val result = session.execute(boundStatement)
@@ -323,5 +323,7 @@ class PreparedStatementsTest extends AbstractIntegrationTest with BeforeAndAfter
     //then
     val results = result.all()
     results.size() should equal(0)
+    val preparedStatements = PrimingHelper.getRecordedPreparedStatements()
+    preparedStatements shouldEqual List(PreparedStatementExecution(preparedStatementText, ONE, List(10), List(CqlBigint)))
   }
 }


### PR DESCRIPTION
See the new test in `PreparedStatementsTest` for an example of the problem being fixed.  Previously the test would fail on the call to `setLong` because the prepared statement result from the stub server did not contain column type information.

Fixes #132 

This is not ready for merge, but I am a bit stuck.  The original bug has been fixed, but some tests are now failing and I don't fully understand why (nor do I understand what they were testing).  In particular, it appears the column_types *were* working for `select` statements and now they aren't.  By *not* sending back column information in the prepare result (just commenting out the `columns.forEach`) fixes the old tests... but of course breaks the new test.