### PR TITLE
Adding support for clearing prepared multi primes

### DIFF
--- a/java-client/src/main/java/org/scassandra/http/client/PrimingClient.java
+++ b/java-client/src/main/java/org/scassandra/http/client/PrimingClient.java
@@ -167,6 +167,10 @@ public class PrimingClient {
         httpDelete(primePreparedUrl);
     }
 
+    public void clearPreparedMultiPrimes() {
+        httpDelete(primePreparedMultiUrl);
+    }
+
     private List<PrimingRequest> httpGetPrimingRequests(String url) {
         HttpGet get = new HttpGet(url);
         try {

--- a/java-client/src/test/java/org/scassandra/http/client/PrimingClientTest.java
+++ b/java-client/src/test/java/org/scassandra/http/client/PrimingClientTest.java
@@ -15,13 +15,6 @@
  */
 package org.scassandra.http.client;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.scassandra.cql.PrimitiveType.*;
-import static org.scassandra.http.client.BatchQueryPrime.batchQueryPrime;
-import static org.scassandra.http.client.MultiPrimeRequest.*;
-
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.common.collect.ImmutableMap;
@@ -30,6 +23,13 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.*;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.scassandra.cql.PrimitiveType.TEXT;
+import static org.scassandra.http.client.BatchQueryPrime.batchQueryPrime;
+import static org.scassandra.http.client.MultiPrimeRequest.*;
 
 public class PrimingClientTest {
 
@@ -740,5 +740,33 @@ public class PrimingClientTest {
                         "{\"variable_matcher\":[{\"matcher\":\"Chris\",\"type\":\"exact\"}]},\"action\":{}}]}}"))
 
         );
+    }
+
+    @Test
+    public void testDeletingOfPreparedMultiPrimes() {
+        //given
+        stubFor(delete(urlEqualTo(PRIME_PREPARED_MULTI_PATH)).willReturn(aResponse().withStatus(200)));
+        //when
+        underTest.clearPreparedMultiPrimes();
+        //then
+        verify(deleteRequestedFor(urlEqualTo(PRIME_PREPARED_MULTI_PATH)));
+    }
+
+    @Test(expected = PrimeFailedException.class)
+    public void testDeletingOfPreparedMultiPrimesFailedDueToStatusCode() {
+        //given
+        stubFor(delete(urlEqualTo(PRIME_PREPARED_MULTI_PATH)).willReturn(aResponse().withStatus(500)));
+        //when
+        underTest.clearPreparedMultiPrimes();
+        //then
+    }
+
+    @Test(expected = PrimeFailedException.class)
+    public void testDeletingOfPreparedMultiPrimesFailed() {
+        //given
+        stubFor(delete(urlEqualTo(PRIME_PREPARED_MULTI_PATH)).willReturn(aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE)));
+        //when
+        underTest.clearQueryPrimes();
+        //then
     }
 }

--- a/server/src/main/scala/org/scassandra/server/priming/prepared/PrimePreparedMultiStore.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/prepared/PrimePreparedMultiStore.scala
@@ -43,4 +43,8 @@ class PrimePreparedMultiStore extends PreparedStoreLookup with LazyLogging {
     state.find({ case (criteria, result) => primeMatch.query == criteria.query &&
       criteria.consistency.contains(primeMatch.consistency) }).map(_._2)
   }
+
+  def clear() = {
+    state = Map()
+  }
 }

--- a/server/src/test/scala/org/scassandra/server/priming/prepared/PrimePreparedMultiStoreTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/prepared/PrimePreparedMultiStoreTest.scala
@@ -104,4 +104,17 @@ class PrimePreparedMultiStoreTest extends FunSuite with Matchers with BeforeAndA
 
     preparedPrime.value.getPrime(List(Some("Daniel"))).fixedDelay should equal(Some(FiniteDuration(500, TimeUnit.MILLISECONDS)))
   }
+
+  test("Clearing all the primes") {
+    //given
+    val variableTypes = List(CqlText)
+    val thenDo: ThenPreparedMulti = ThenPreparedMulti(Some(variableTypes), List(
+      Outcome(Criteria(List(ExactMatch(Some("Chris")))), Action(Some(List()), result = Some(Success)))))
+    val queryText = "Some query"
+    underTest.record(PrimePreparedMulti(WhenPrepared(Some(queryText)), thenDo))
+    //when
+    underTest.clear()
+    //then
+    underTest.state.size should equal(0)
+  }
 }

--- a/server/src/test/scala/org/scassandra/server/priming/routes/PrimingPreparedRouteTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/routes/PrimingPreparedRouteTest.scala
@@ -72,6 +72,13 @@ class PrimingPreparedRouteTest extends FunSpec with Matchers with ScalatestRoute
       }
     }
 
+    it("Should allow primes to be deleted") {
+      Delete(primePreparedMultiPath) ~> routeForPreparedPriming ~> check {
+        status should equal(StatusCodes.OK)
+        verify(primePreparedMultiStore).clear()
+      }
+    }
+
     //todo validation error if variable types length != outcome varaiable matcher length
   }
 


### PR DESCRIPTION
We're using the prepared multi primes that were recently introduced. Like with the other priming methods, we need to be able to clear the prepared multi primes. This change adds support to the web API and the Java client.