### PR TITLE
Update akka to 2.4.2. Update other dependencies. Fix broken tests.

### DIFF
--- a/java-client/build.gradle
+++ b/java-client/build.gradle
@@ -131,7 +131,7 @@ dependencies {
     testCompile 'com.github.tomakehurst:wiremock:1.46'
     testCompile 'nl.jqno.equalsverifier:equalsverifier:1.7.3'
     testCompile "com.googlecode.jarjar:jarjar:1.3"
-    testCompile('com.datastax.cassandra:cassandra-driver-core:2.0.5')
+    testCompile('com.datastax.cassandra:cassandra-driver-core:2.1.10')
 }
 
 task wrapper(type: Wrapper) {

--- a/java-it-tests/common/src/main/java/common/AbstractScassandraTest.java
+++ b/java-it-tests/common/src/main/java/common/AbstractScassandraTest.java
@@ -56,7 +56,7 @@ abstract public class AbstractScassandraTest {
     }
 
     public static Map<String, CqlType> cqlTypes(Map<String, ColumnTypes> columnTypes) {
-        return Maps.transformValues(columnTypes, input -> input.getType());
+        return Maps.transformValues(columnTypes, ColumnTypes::getType);
     }
 
     public static byte[] getArray(ByteBuffer buffer) {

--- a/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementErrorPrimingTest.java
+++ b/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementErrorPrimingTest.java
@@ -113,7 +113,7 @@ abstract public class PreparedStatementErrorPrimingTest extends AbstractScassand
     public void testPrimingServerError() {
         String errorMessage = "Arbitrary Server Error";
         ErrorMessageConfig config = new ErrorMessageConfig(errorMessage);
-        assertErrorMessageStatus(server_error, config, "Host replied with server error: " + errorMessage);
+        assertErrorMessageStatus(server_error, config, errorMessage);
     }
 
     @Test
@@ -133,14 +133,14 @@ abstract public class PreparedStatementErrorPrimingTest extends AbstractScassand
     @Test
     public void testOverloadedError() {
         ErrorMessageConfig config = new ErrorMessageConfig("");
-        assertErrorMessageStatus(overloaded, config, "Host overloaded");
+        assertErrorMessageStatus(overloaded, config, "overloaded");
     }
 
     @Test
     public void testIsBootstrapping() {
         String errorMessage = "Lay off, i'm bootstrapping.";
         ErrorMessageConfig config = new ErrorMessageConfig(errorMessage);
-        assertErrorMessageStatus(is_bootstrapping, config, "Host is bootstrapping");
+        assertErrorMessageStatus(is_bootstrapping, config, "bootstrapping");
     }
 
     @Test

--- a/java-it-tests/common/src/main/java/queries/QueryErrorPrimingTest.java
+++ b/java-it-tests/common/src/main/java/queries/QueryErrorPrimingTest.java
@@ -116,7 +116,7 @@ abstract public class QueryErrorPrimingTest extends AbstractScassandraTest {
     public void testPrimingServerError() {
         String errorMessage = "Arbitrary Server Error";
         ErrorMessageConfig config = new ErrorMessageConfig(errorMessage);
-        assertErrorMessageStatus(server_error, config, "Host replied with server error: " + errorMessage);
+        assertErrorMessageStatus(server_error, config, errorMessage);
     }
 
     @Test
@@ -136,14 +136,14 @@ abstract public class QueryErrorPrimingTest extends AbstractScassandraTest {
     @Test
     public void testOverloadedError() {
         ErrorMessageConfig config = new ErrorMessageConfig("");
-        assertErrorMessageStatus(overloaded, config, "Host overloaded");
+        assertErrorMessageStatus(overloaded, config, "overloaded");
     }
 
     @Test
     public void testIsBootstrapping() {
         String errorMessage = "Lay off, i'm bootstrapping.";
         ErrorMessageConfig config = new ErrorMessageConfig(errorMessage);
-        assertErrorMessageStatus(is_bootstrapping, config, "Host is bootstrapping");
+        assertErrorMessageStatus(is_bootstrapping, config, "bootstrapping");
     }
 
     @Test

--- a/java-it-tests/driver21/src/test/java/cassandra/CassandraExecutor21.java
+++ b/java-it-tests/driver21/src/test/java/cassandra/CassandraExecutor21.java
@@ -146,9 +146,9 @@ public class CassandraExecutor21 implements CassandraExecutor {
                 // tries another host.
                 if(message.contains("protocol error")) {
                     error = protocol_error;
-                } else if(message.contains("Host overloaded")) {
+                } else if(message.contains("was overloaded")) {
                     error = overloaded;
-                } else if(message.contains("Host is bootstrapping")) {
+                } else if(message.contains("was bootstrapping")) {
                     error = is_bootstrapping;
                 }
             } catch(Throwable t) {} // unknown error we can handle later.

--- a/java-it-tests/driver30/src/test/java/cassandra/CassandraExecutor30.java
+++ b/java-it-tests/driver30/src/test/java/cassandra/CassandraExecutor30.java
@@ -147,9 +147,9 @@ public class CassandraExecutor30 implements CassandraExecutor {
                 // tries another host.
                 if (message.contains("protocol error")) {
                     error = protocol_error;
-                } else if (message.contains("Host overloaded")) {
+                } else if (message.contains("was overloaded")) {
                     error = overloaded;
-                } else if (message.contains("Host is bootstrapping")) {
+                } else if (message.contains("was bootstrapping")) {
                     error = is_bootstrapping;
                 }
             } catch (Throwable t) {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -131,8 +131,8 @@ uploadArchives {
 dependencies {
     compile 'org.scala-lang:scala-library:2.11.7'
     compile  "ch.qos.logback:logback-classic:1.0.13"
-    compile  "com.typesafe.akka:akka-actor_2.11:2.3.9"
-    compile  "com.typesafe.akka:akka-remote_2.11:2.3.9"
+    compile  "com.typesafe.akka:akka-actor_2.11:2.4.2"
+    compile  "com.typesafe.akka:akka-remote_2.11:2.4.2"
     compile  "io.spray:spray-json_2.11:1.3.2"
     compile  "io.spray:spray-can_2.11:1.3.3"
     compile  "io.spray:spray-routing_2.11:1.3.3"
@@ -140,13 +140,13 @@ dependencies {
     compile  "com.google.guava:guava:17.0"
     compile  "org.scassandra:cql-antlr:0.1.0"
 
-    testCompile "com.typesafe.akka:akka-testkit_2.11:2.3.9"
+    testCompile "com.typesafe.akka:akka-testkit_2.11:2.4.2"
     testCompile "io.spray:spray-testkit_2.11:1.3.3"
-    testCompile "com.datastax.cassandra:cassandra-driver-core:2.0.10" //exclude("com.google.guava", "guava"),
-    testCompile "net.databinder.dispatch:dispatch-core_2.11:0.11.0"
+    testCompile "com.datastax.cassandra:cassandra-driver-core:2.1.10" //exclude("com.google.guava", "guava"),
+    testCompile "net.databinder.dispatch:dispatch-core_2.11:0.11.3"
     testCompile "org.scalatest:scalatest_2.11:2.2.3"
     testCompile "org.mockito:mockito-core:1.9.5"
-    testRuntime 'org.pegdown:pegdown:1.1.0'
+    testRuntime 'org.pegdown:pegdown:1.6.0'
 }
 
 test {

--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -13,7 +13,7 @@ scassandra.startup-timeout-ms=2000
 
 akka {
   # Akka version, checked against the runtime version of Akka.
-  version = "2.3.9"
+  version = "2.4.2"
 
   # Home directory of Akka, modules in the deploy directory will be loaded
   home = ""

--- a/server/src/test/resources/reference.conf
+++ b/server/src/test/resources/reference.conf
@@ -12,7 +12,7 @@ scassandra.admin.listen-address=localhost
 
 akka {
   # Akka version, checked against the runtime version of Akka.
-  version = "2.3.9"
+  version = "2.4.2"
 
   # Home directory of Akka, modules in the deploy directory will be loaded
   home = ""

--- a/server/src/test/scala/org/scassandra/server/JavaDriverIntegrationTest.scala
+++ b/server/src/test/scala/org/scassandra/server/JavaDriverIntegrationTest.scala
@@ -18,6 +18,8 @@ package org.scassandra.server
 import com.datastax.driver.core.exceptions.{SyntaxError => SyntaxErrorDriver, _}
 import org.scalatest.concurrent.ScalaFutures
 import org.scassandra.server.priming.ErrorConstants
+import org.scassandra.server.priming.json.ProtocolError
+import org.scassandra.server.priming.json.ServerError
 import org.scassandra.server.priming.json._
 import org.scassandra.server.priming.query.{Then, When}
 
@@ -83,7 +85,7 @@ class JavaDriverIntegrationTest extends AbstractIntegrationTest with ScalaFuture
   }
 
   test("Test unavailable exception on query") {
-    expectException[UnavailableException](Unavailable)
+    expectException[NoHostAvailableException](Unavailable)
   }
 
   test("Test write timeout on query") {
@@ -128,9 +130,7 @@ class JavaDriverIntegrationTest extends AbstractIntegrationTest with ScalaFuture
     expectException[InvalidQueryException](Invalid)
   }
 
-  ignore("Test config error on query") {
-    // Ignored since this is a bug in the java driver as it returns
-    // the wrong exception.
+  test("Test config error on query") {
     expectException[InvalidConfigurationInQueryException](ConfigError)
   }
 

--- a/server/src/test/scala/org/scassandra/server/e2e/verification/ConnectionVerificationTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/verification/ConnectionVerificationTest.scala
@@ -52,8 +52,8 @@ class ConnectionVerificationTest extends AbstractIntegrationTest with ScalaFutur
     whenReady(response) {
       result =>
         val connectionList = JsonParser(result).convertTo[List[Connection]]
-        // The java driver establishes 1 control + core connections.
-        connectionList.size should equal(1 + cluster
+        // The java driver establishes 1 control + core connections + 1?.
+        connectionList.size should equal(2 + cluster
           .getConfiguration
           .getPoolingOptions
           .getCoreConnectionsPerHost(HostDistance.LOCAL))


### PR DESCRIPTION
Few concerns here:
 - UnavailableException replaced by NoHostAvailableException (which wraps the original).
 - Overloaded and bootstrapping messages no longer consistent between 20 and 21 tests.
 - 1 extra connection appears from somewhere with driver update.