### PR TITLE
ISSUE-145: Akka configuration fix

### DIFF
--- a/java-client/build.gradle
+++ b/java-client/build.gradle
@@ -139,7 +139,7 @@ task wrapper(type: Wrapper) {
 }
 
 shadowJar {
-    append('reference.conf')
+    append('application.conf')
     relocate 'org.apache.cassandra', 'scassandra.org.apache.cassandra'
     relocate 'org.mortbay', 'scassandra.org.mortbay'
     relocate 'com.google.common', 'scassandra.com.google.common'

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -2,6 +2,7 @@ scassandra.binary.port=8042
 scassandra.binary.listen-address=localhost
 scassandra.admin.port=8043
 scassandra.admin.listen-address=localhost
+scassandra.startup-timeout-ms=2000
 
 ####################################
 # Akka Actor Reference Config File #
@@ -11,8 +12,6 @@ scassandra.admin.listen-address=localhost
 # Make your edits/overrides in your application.conf.
 
 akka {
-  # Akka version, checked against the runtime version of Akka.
-  version = "2.3.9"
 
   # Home directory of Akka, modules in the deploy directory will be loaded
   home = ""
@@ -35,7 +34,7 @@ akka {
   # Log level used by the configured loggers (see "loggers") as soon
   # as they have been started; before that, see "stdout-loglevel"
   # Options: OFF, ERROR, WARNING, INFO, DEBUG
-  loglevel = "DEBUG"
+  loglevel = "INFO"
 
   # Log level for the very basic logger activated during AkkaApplication startup
   # Options: OFF, ERROR, WARNING, INFO, DEBUG

--- a/server/src/test/resources/application.conf
+++ b/server/src/test/resources/application.conf
@@ -2,7 +2,6 @@ scassandra.binary.port=8042
 scassandra.binary.listen-address=localhost
 scassandra.admin.port=8043
 scassandra.admin.listen-address=localhost
-scassandra.startup-timeout-ms=2000
 
 ####################################
 # Akka Actor Reference Config File #
@@ -12,8 +11,6 @@ scassandra.startup-timeout-ms=2000
 # Make your edits/overrides in your application.conf.
 
 akka {
-  # Akka version, checked against the runtime version of Akka.
-  version = "2.3.9"
 
   # Home directory of Akka, modules in the deploy directory will be loaded
   home = ""
@@ -36,7 +33,7 @@ akka {
   # Log level used by the configured loggers (see "loggers") as soon
   # as they have been started; before that, see "stdout-loglevel"
   # Options: OFF, ERROR, WARNING, INFO, DEBUG
-  loglevel = "INFO"
+  loglevel = "DEBUG"
 
   # Log level for the very basic logger activated during AkkaApplication startup
   # Options: OFF, ERROR, WARNING, INFO, DEBUG


### PR DESCRIPTION
Fixes problem described here - https://github.com/scassandra/scassandra-server/issues/145
Users of stubbed cassandra are not restricted to defined `akka.version` anymore.

- [x] Ready for review 