### PR TITLE
Allowing use of shapeless 2.x

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -135,7 +135,7 @@ dependencies {
     compile  "com.typesafe.akka:akka-remote_2.11:2.3.9"
     compile  "io.spray:spray-json_2.11:1.3.2"
     compile  "io.spray:spray-can_2.11:1.3.3"
-    compile  "io.spray:spray-routing_2.11:1.3.3"
+    compile  "io.spray:spray-routing-shapeless2_2.11:1.3.3"
     compile  "com.typesafe.scala-logging:scala-logging_2.11:3.1.0"
     compile  "com.google.guava:guava:17.0"
     compile  "org.scassandra:cql-antlr:0.1.0"


### PR DESCRIPTION
Fixes problem with both shapeless 1.x and 2.x on classpath
- [x] Ready for review