### PR TITLE
Introducing alias for Then to avoid reserved word issues

### DIFF
--- a/java-client/src/main/java/org/scassandra/http/client/PrimingRequest.java
+++ b/java-client/src/main/java/org/scassandra/http/client/PrimingRequest.java
@@ -34,6 +34,10 @@ public final class PrimingRequest {
         return new Then.ThenBuilder();
     }
 
+    public static Then.ThenBuilder andThen() {
+        return then();
+    }
+
     transient PrimingRequestBuilder.PrimeType primeType;
 
     public static class PrimingRequestBuilder {


### PR DESCRIPTION
Avoids ```then is now a reserved word; usage as an identifier is deprecated``` error from newer Scala versions. 

- [x] Ready for review