### PR TITLE
Handle invalid types with an informative error message, update docs.

### DIFF
--- a/docs/standalone/priming-cluster-name.md
+++ b/docs/standalone/priming-cluster-name.md
@@ -27,7 +27,7 @@ The Java Datastax Driver looks in the system.local table for the cluster\_name. 
     ],
     "result": "success",
     "column_types": {
-      "tokens": "set"
+      "tokens": "set<text>"
     }
   }
 }
@@ -59,7 +59,7 @@ The 1.* driver executes a different query;
     ],
     "result": "success",
     "column_types": {
-      "tokens": "Set"
+      "tokens": "set<text>"
     }
   }
 }
@@ -80,7 +80,7 @@ If you're using the Scassandra java client you'll need something like:
 
 
 ```java
- Map<String, ColumnTypes> columnTypes = ImmutableMap.of("tokens",ColumnTypes.Set);
+ Map<String, ColumnTypes> columnTypes = ImmutableMap.of("tokens",SetType.set(PrimitiveType.TEXT));
         String query = "SELECT cluster_name, data_center, rack, tokens, partitioner FROM system.local WHERE key='local'";
         Map<String, Object> row = new HashMap<>();
         row.put("cluster_name", CUSTOM_CLUSTER_NAME);

--- a/docs/standalone/priming-query.md
+++ b/docs/standalone/priming-query.md
@@ -324,7 +324,7 @@ Varchars can be primed in two ways.
    },
    "then": {
      "rows" :[{"column1": ["one", "two", "three"]}] ,
-     "column_types" : { "column1" : "set"}
+     "column_types" : { "column1" : "set<text>"}
    }
  }
 ```

--- a/docs/standalone/using-python.md
+++ b/docs/standalone/using-python.md
@@ -51,7 +51,7 @@ Example prime:
       "partitioner": "varchar",
       "data_center": "varchar",
       "rack": "varchar",
-      "tokens": "set",
+      "tokens": "set<text>",
       "release_version": "varchar"
     }
   }
@@ -82,7 +82,7 @@ Example prime:
     ],
     "result": "success",
     "column_types": {
-      "tokens": "uuid"
+      "schema_version": "uuid"
     }
   }
 }

--- a/server/src/main/scala/org/scassandra/server/priming/json/PrimingJsonImplicits.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/json/PrimingJsonImplicits.scala
@@ -17,6 +17,7 @@ import spray.httpx.SprayJsonSupport
 import spray.json._
 
 import scala.collection.Set
+import scala.util.{Failure, Success => TSuccess}
 
 object PrimingJsonImplicits extends DefaultJsonProtocol with SprayJsonSupport with LazyLogging {
 
@@ -121,10 +122,10 @@ object PrimingJsonImplicits extends DefaultJsonProtocol with SprayJsonSupport wi
 
     def read(value: JsValue) = value match {
       case JsString(string) => ColumnType.fromString(string) match {
-        case Some(columnType) => columnType
-        case None =>
-          logger.warn(s"Received invalid column type $string")
-          throw new IllegalArgumentException("Not a valid column type " + string)
+        case TSuccess(columnType) => columnType
+        case Failure(e) =>
+          logger.warn(s"Received invalid column type '$string'", e)
+          throw new IllegalArgumentException(s"Not a valid column type '$string'")
       }
       case _ => throw new IllegalArgumentException("Expected ColumnType as JsString")
     }


### PR DESCRIPTION
Noticed that some of the docs inappropriately reference a 'set' column_type without providing a parameterized value.   This used to work but no longer does, when it does the error returned is not very useful:

```
The request content was malformed:
```

Updated `ColumnType.fromString` to handle any parsing errors emitted by `CqlTypeFactory.buildType` and returning `Try` instead of `Option` and then handling the `Failure` case in `PrimingJsonImplicits.ColumnTypeJsonFormat`.

The error now includes the relevant info:

```
The request content was malformed:
Not a valid column type 'set'
```

and the full stack trace is emitted in the logs.