### PR TITLE
Provide custom configuration for batch result

### DIFF
--- a/server/src/main/scala/org/scassandra/server/priming/batch/PrimeBatchStore.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/batch/PrimeBatchStore.scala
@@ -11,7 +11,7 @@ class PrimeBatchStore extends LazyLogging {
   var primes: Map[BatchCriteria, BatchPrime] = Map()
   
   def record(prime: BatchPrimeSingle): Unit = {
-    val result: PrimeResult = PrimingJsonHelper.convertToPrimeResult(Map(), prime.thenDo.result.getOrElse(Success))
+    val result: PrimeResult = PrimingJsonHelper.convertToPrimeResult(prime.thenDo.config.getOrElse(Map()), prime.thenDo.result.getOrElse(Success))
     val consistencies: List[Consistency] = prime.when.consistency.getOrElse(Consistency.all)
     primes += (BatchCriteria(prime.when.queries, consistencies, prime.when.batchType.getOrElse(LOGGED)) -> BatchPrime(result, prime.thenDo.fixedDelay))
   }

--- a/server/src/test/scala/org/scassandra/server/priming/batch/PrimeBatchStoreTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/batch/PrimeBatchStoreTest.scala
@@ -1,9 +1,9 @@
 package org.scassandra.server.priming.batch
 
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.{FunSpec, Matchers}
 import org.scassandra.server.cqlmessages._
-import org.scassandra.server.priming.{BatchQuery, BatchExecution, SuccessResult}
-import org.scassandra.server.priming.json.Success
+import org.scassandra.server.priming._
+import org.scassandra.server.priming.json.{Success, WriteTimeout}
 import org.scassandra.server.priming.query.Then
 
 class PrimeBatchStoreTest extends FunSpec with Matchers {
@@ -21,28 +21,28 @@ class PrimeBatchStoreTest extends FunSpec with Matchers {
     }
 
     it("Should fail if single query does not match") {
-        val underTest = new PrimeBatchStore()
+      val underTest = new PrimeBatchStore()
 
-        underTest.record(BatchPrimeSingle(
-          BatchWhen(List(BatchQueryPrime("select * blah", QueryKind))),
-          Then(result = Some(Success))))
+      underTest.record(BatchPrimeSingle(
+        BatchWhen(List(BatchQueryPrime("select * blah", QueryKind))),
+        Then(result = Some(Success))))
 
-        val prime = underTest.findPrime(BatchExecution(Seq(BatchQuery("I am do different", QueryKind)), ONE, LOGGED))
+      val prime = underTest.findPrime(BatchExecution(Seq(BatchQuery("I am do different", QueryKind)), ONE, LOGGED))
 
-        prime should equal(None)
+      prime should equal(None)
     }
 
     it("Should fail if any query does not match") {
-        val underTest = new PrimeBatchStore()
+      val underTest = new PrimeBatchStore()
 
-        underTest.record(BatchPrimeSingle(
-          BatchWhen(List(BatchQueryPrime("select * blah", QueryKind),
-            BatchQueryPrime("select * wah", PreparedStatementKind))),
-          Then(result = Some(Success))))
+      underTest.record(BatchPrimeSingle(
+        BatchWhen(List(BatchQueryPrime("select * blah", QueryKind),
+          BatchQueryPrime("select * wah", PreparedStatementKind))),
+        Then(result = Some(Success))))
 
-        val prime = underTest.findPrime(BatchExecution(Seq(BatchQuery("select * blah", QueryKind)), ONE, LOGGED))
+      val prime = underTest.findPrime(BatchExecution(Seq(BatchQuery("select * blah", QueryKind)), ONE, LOGGED))
 
-        prime should equal(None)
+      prime should equal(None)
     }
 
     it("Should match if all queries match") {
@@ -86,6 +86,31 @@ class PrimeBatchStoreTest extends FunSpec with Matchers {
       val prime = underTest.findPrime(BatchExecution(Seq(BatchQuery("select * blah", QueryKind)), ONE, LOGGED))
 
       prime should equal(None)
+    }
+
+    it("Should record a batch WriteTimeout with default configuration") {
+      val underTest = new PrimeBatchStore()
+
+      underTest.record(BatchPrimeSingle(
+        BatchWhen(List(BatchQueryPrime("select * blah", QueryKind))),
+        Then(result = Some(WriteTimeout))))
+
+      val prime = underTest.findPrime(BatchExecution(Seq(BatchQuery("select * blah", QueryKind)), ONE, LOGGED))
+
+      prime should equal(Some(BatchPrime(WriteRequestTimeoutResult(), None)))
+    }
+
+    it("Should record a batch WriteTimeout with custom configuration") {
+      val underTest = new PrimeBatchStore()
+
+      val config: Map[String, String] = Map(ErrorConstants.WriteType -> WriteType.BATCH.toString)
+      underTest.record(BatchPrimeSingle(
+        BatchWhen(List(BatchQueryPrime("select * blah", QueryKind))),
+        Then(result = Some(WriteTimeout), config = Option(config))))
+
+      val prime = underTest.findPrime(BatchExecution(Seq(BatchQuery("select * blah", QueryKind)), ONE, LOGGED))
+
+      prime should equal(Some(BatchPrime(WriteRequestTimeoutResult(writeType = WriteType.BATCH), None)))
     }
   }
 }


### PR DESCRIPTION
Allow providing a custom WriteType value for a batch execution via the
Then configuration options.