### PR TITLE
Make integration tests suitable for concurrent run.

### DIFF
--- a/java-it-tests/common/src/main/java/common/AbstractScassandraTest.java
+++ b/java-it-tests/common/src/main/java/common/AbstractScassandraTest.java
@@ -15,8 +15,10 @@ import org.scassandra.http.client.ActivityClient;
 import org.scassandra.http.client.ColumnTypes;
 import org.scassandra.http.client.PrimingClient;
 
+import static common.PortLocator.*;
+
 abstract public class AbstractScassandraTest {
-    private static Scassandra scassandra;
+    protected static Scassandra scassandra;
     protected static PrimingClient primingClient;
     protected static ActivityClient activityClient;
 
@@ -29,7 +31,7 @@ abstract public class AbstractScassandraTest {
 
     @BeforeClass
     public static void startScassandra() {
-        scassandra = ScassandraFactory.createServer();
+        scassandra = ScassandraFactory.createServer(findFreePort(), findFreePort());
         primingClient = scassandra.primingClient();
         activityClient = scassandra.activityClient();
         scassandra.start();

--- a/java-it-tests/common/src/main/java/common/Config.java
+++ b/java-it-tests/common/src/main/java/common/Config.java
@@ -1,7 +1,6 @@
 package common;
 
 public class Config {
-    public static final int NATIVE_PORT = 8042;
     public static final String NATIVE_HOST = "localhost";
     public static final String KEYSPACE = "keyspace";
 }

--- a/java-it-tests/common/src/main/java/common/PortLocator.java
+++ b/java-it-tests/common/src/main/java/common/PortLocator.java
@@ -1,0 +1,40 @@
+package common;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.Random;
+
+public class PortLocator {
+    private static final int MIN_PORT = 1024;
+    private static final int MAX_PORT = 65535;
+    private static final int MAX_PORT_FAILURES = 10;
+    private static final int CONNECT_TIMEOUT_MS = 2000;
+    private static final Random random = new Random(System.currentTimeMillis());
+
+    public static int findFreePort() {
+        for (int attempts = 1; attempts <= MAX_PORT_FAILURES; attempts++) {
+            int port = randomPort();
+            if (portFree(port)) {
+                return port;
+            }
+        }
+        throw new IllegalStateException("Not possible to find any free port");
+    }
+
+    private static int randomPort() {
+        int range = MAX_PORT - MIN_PORT;
+        return MIN_PORT + random.nextInt(range + 1);
+    }
+
+    private static boolean portFree(int port) {
+        try {
+            Socket socket = new Socket();
+            socket.connect(new InetSocketAddress("localhost", port), CONNECT_TIMEOUT_MS);
+            socket.close();
+            return false;
+        } catch (IOException e) {
+            return true;
+        }
+    }
+}

--- a/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementErrorPrimingTest.java
+++ b/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementErrorPrimingTest.java
@@ -127,7 +127,8 @@ abstract public class PreparedStatementErrorPrimingTest extends AbstractScassand
     public void testBadCredentials() {
         String errorMessage = "Bad Credentials";
         ErrorMessageConfig config = new ErrorMessageConfig(errorMessage);
-        assertErrorMessageStatus(bad_credentials, config, "Authentication error on host localhost/127.0.0.1:8042: " + errorMessage);
+        assertErrorMessageStatus(bad_credentials, config,
+                String.format("Authentication error on host localhost/127.0.0.1:%s: ", scassandra.getBinaryPort()) + errorMessage);
     }
 
     @Test
@@ -202,7 +203,8 @@ abstract public class PreparedStatementErrorPrimingTest extends AbstractScassand
     public void testClosedOnRequest() {
         ClosedConnectionConfig config = new ClosedConnectionConfig(ClosedConnectionConfig.CloseType.CLOSE);
         assertErrorMessageStatus(closed_connection, config,
-            "All host(s) tried for query failed (tried: localhost/127.0.0.1:8042 (com.datastax.driver.core.TransportException: [localhost/127.0.0.1:8042] Connection has been closed))",
+            String.format("All host(s) tried for query failed (tried: localhost/127.0.0.1:%s (com.datastax.driver.core.TransportException: [localhost/127.0.0.1:%s] Connection has been closed))",
+                    scassandra.getBinaryPort(), scassandra.getBinaryPort()),
             server_error);
     }
 

--- a/java-it-tests/common/src/main/java/queries/QueryErrorPrimingTest.java
+++ b/java-it-tests/common/src/main/java/queries/QueryErrorPrimingTest.java
@@ -130,7 +130,8 @@ abstract public class QueryErrorPrimingTest extends AbstractScassandraTest {
     public void testBadCredentials() {
         String errorMessage = "Bad Credentials";
         ErrorMessageConfig config = new ErrorMessageConfig(errorMessage);
-        assertErrorMessageStatus(bad_credentials, config, "Authentication error on host localhost/127.0.0.1:8042: " + errorMessage);
+        assertErrorMessageStatus(bad_credentials, config,
+                String.format("Authentication error on host localhost/127.0.0.1:%s: ", scassandra.getBinaryPort()) + errorMessage);
     }
 
     @Test
@@ -208,7 +209,8 @@ abstract public class QueryErrorPrimingTest extends AbstractScassandraTest {
     public void testClosedOnRequest() {
         ClosedConnectionConfig config = new ClosedConnectionConfig(ClosedConnectionConfig.CloseType.RESET);
         assertErrorMessageStatus(closed_connection, config,
-            "All host(s) tried for query failed (tried: localhost/127.0.0.1:8042 (com.datastax.driver.core.TransportException: [localhost/127.0.0.1:8042] Connection has been closed))",
+            String.format("All host(s) tried for query failed (tried: localhost/127.0.0.1:%s (com.datastax.driver.core.TransportException: [localhost/127.0.0.1:%s] Connection has been closed))",
+                    scassandra.getBinaryPort(), scassandra.getBinaryPort()),
             server_error);
     }
 

--- a/java-it-tests/driver20/src/test/java/batches/BatchActivityVerificationTest20.java
+++ b/java-it-tests/driver20/src/test/java/batches/BatchActivityVerificationTest20.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor20;
 
 public class BatchActivityVerificationTest20 extends BatchActivityVerificationTest {
     public BatchActivityVerificationTest20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/batches/BatchPrimingTest20.java
+++ b/java-it-tests/driver20/src/test/java/batches/BatchPrimingTest20.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor20;
 
 public class BatchPrimingTest20 extends BatchPrimingTest {
     public BatchPrimingTest20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/cassandra/CassandraExecutor20.java
+++ b/java-it-tests/driver20/src/test/java/cassandra/CassandraExecutor20.java
@@ -27,7 +27,7 @@ public class CassandraExecutor20 implements CassandraExecutor {
     private Cluster cluster;
     private Session session;
 
-    public CassandraExecutor20() {
+    public CassandraExecutor20(int binaryPort) {
         NettyOptions closeQuickly = new NettyOptions() {
             public void onClusterClose(EventLoopGroup eventLoopGroup) {
                 //Shutdown immediately, since we close cluster when finished, we know nothing new coming through.
@@ -35,7 +35,7 @@ public class CassandraExecutor20 implements CassandraExecutor {
             }
         };
         cluster = Cluster.builder().addContactPoint(Config.NATIVE_HOST)
-                .withPort(Config.NATIVE_PORT)
+                .withPort(binaryPort)
                 .withNettyOptions(closeQuickly)
                 .build();
         session = cluster.connect(Config.KEYSPACE);

--- a/java-it-tests/driver20/src/test/java/just20/MetaDataPriming20.java
+++ b/java-it-tests/driver20/src/test/java/just20/MetaDataPriming20.java
@@ -18,7 +18,6 @@ import com.datastax.driver.core.Cluster;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import common.AbstractScassandraTest;
-import common.Config;
 import org.junit.Test;
 import org.scassandra.http.client.ColumnTypes;
 import org.scassandra.http.client.PrimingRequest;
@@ -32,7 +31,7 @@ public class MetaDataPriming20 extends AbstractScassandraTest {
     public static final String CUSTOM_CLUSTER_NAME = "custom cluster name";
 
     public MetaDataPriming20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 
     @Test
@@ -56,7 +55,7 @@ public class MetaDataPriming20 extends AbstractScassandraTest {
 
         //when
         Cluster cluster = Cluster.builder().addContactPoint("localhost")
-                .withPort(Config.NATIVE_PORT).build();
+                .withPort(scassandra.getBinaryPort()).build();
         cluster.connect();
 
         //then

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementCollectionVariables20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementCollectionVariables20.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor20;
 public class PreparedStatementCollectionVariables20 extends PreparedStatementCollectionVariables {
 
     public PreparedStatementCollectionVariables20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementDelayTest20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementDelayTest20.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor20;
 
 public class PreparedStatementDelayTest20 extends PreparedStatementDelayTest {
     public PreparedStatementDelayTest20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementErrorPrimingTest20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementErrorPrimingTest20.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor20;
 public class PreparedStatementErrorPrimingTest20 extends PreparedStatementErrorPrimingTest {
 
     public PreparedStatementErrorPrimingTest20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementPreparationTest20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementPreparationTest20.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor20;
 
 public class PreparedStatementPreparationTest20 extends PreparedStatementPreparationTest {
     public PreparedStatementPreparationTest20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementPrimeOnVariablesTest20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementPrimeOnVariablesTest20.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor20;
 
 public class PreparedStatementPrimeOnVariablesTest20 extends PreparedStatementPrimeOnVariables {
     public PreparedStatementPrimeOnVariablesTest20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableTypes20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableTypes20.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor20;
 public class PreparedStatementPrimitiveVariableTypes20 extends PreparedStatementPrimitiveVariableTypes {
 
     public PreparedStatementPrimitiveVariableTypes20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableWithMatcherTypes20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableWithMatcherTypes20.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor20;
 
 public class PreparedStatementPrimitiveVariableWithMatcherTypes20 extends PreparedStatementPrimitiveVariableWithMatcherTypes {
     public PreparedStatementPrimitiveVariableWithMatcherTypes20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementTest20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementTest20.java
@@ -19,6 +19,6 @@ import cassandra.CassandraExecutor20;
 public class PreparedStatementTest20 extends PreparedStatementTest {
 
     public PreparedStatementTest20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementsListVariablesWithMatcher20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementsListVariablesWithMatcher20.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor20;
 
 public class PreparedStatementsListVariablesWithMatcher20 extends PreparedStatementsListVariablesWithMatcher {
     public PreparedStatementsListVariablesWithMatcher20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementsMapVariablesWithMatcher20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementsMapVariablesWithMatcher20.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor20;
 
 public class PreparedStatementsMapVariablesWithMatcher20 extends PreparedStatementsMapVariablesWithMatcher {
     public PreparedStatementsMapVariablesWithMatcher20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementsSetVariablesWithMatcher20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementsSetVariablesWithMatcher20.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor20;
 
 public class PreparedStatementsSetVariablesWithMatcher20 extends PreparedStatementsSetVariablesWithMatcher {
     public PreparedStatementsSetVariablesWithMatcher20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementsWithPattern20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementsWithPattern20.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor20;
 public class PreparedStatementsWithPattern20 extends PreparedStatementsWithPattern {
 
     public PreparedStatementsWithPattern20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/queries/BasicPrimingTest20.java
+++ b/java-it-tests/driver20/src/test/java/queries/BasicPrimingTest20.java
@@ -19,6 +19,6 @@ import cassandra.CassandraExecutor20;
 public class BasicPrimingTest20 extends BasicPrimingTest {
 
     public BasicPrimingTest20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/queries/DelayTest20.java
+++ b/java-it-tests/driver20/src/test/java/queries/DelayTest20.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor20;
 
 public class DelayTest20 extends DelayTest {
     public DelayTest20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/queries/PrimingCollectionsForQuery20.java
+++ b/java-it-tests/driver20/src/test/java/queries/PrimingCollectionsForQuery20.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor20;
 
 public class PrimingCollectionsForQuery20 extends PrimingMapsForQuery {
     public PrimingCollectionsForQuery20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/queries/PrimingListsForQuery20.java
+++ b/java-it-tests/driver20/src/test/java/queries/PrimingListsForQuery20.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor20;
 
 public class PrimingListsForQuery20 extends PrimingListsForQuery {
     public PrimingListsForQuery20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/queries/PrimingPrimitiveTypesForQuery20.java
+++ b/java-it-tests/driver20/src/test/java/queries/PrimingPrimitiveTypesForQuery20.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor20;
 public class PrimingPrimitiveTypesForQuery20 extends PrimingPrimitiveTypesForQuery {
 
     public PrimingPrimitiveTypesForQuery20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/queries/PrimingSetsForQuery20.java
+++ b/java-it-tests/driver20/src/test/java/queries/PrimingSetsForQuery20.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor20;
 
 public class PrimingSetsForQuery20 extends PrimingSetsForQuery {
     public PrimingSetsForQuery20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/queries/PrimingTimestamps20.java
+++ b/java-it-tests/driver20/src/test/java/queries/PrimingTimestamps20.java
@@ -19,6 +19,6 @@ import cassandra.CassandraExecutor20;
 public class PrimingTimestamps20 extends PrimingTimestamps {
 
     public PrimingTimestamps20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/queries/PrimingWithPattern20.java
+++ b/java-it-tests/driver20/src/test/java/queries/PrimingWithPattern20.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor20;
 public class PrimingWithPattern20 extends PrimingWithPattern {
 
     public PrimingWithPattern20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/queries/QueryBuilderTest20.java
+++ b/java-it-tests/driver20/src/test/java/queries/QueryBuilderTest20.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor20;
 
 public class QueryBuilderTest20 extends QueryBuilderTest {
     public QueryBuilderTest20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver20/src/test/java/queries/QueryErrorPrimingTest20.java
+++ b/java-it-tests/driver20/src/test/java/queries/QueryErrorPrimingTest20.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor20;
 public class QueryErrorPrimingTest20 extends QueryErrorPrimingTest {
 
     public QueryErrorPrimingTest20() {
-        super(new CassandraExecutor20());
+        super(new CassandraExecutor20(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/batches/BatchActivityVerificationTest21.java
+++ b/java-it-tests/driver21/src/test/java/batches/BatchActivityVerificationTest21.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor21;
 
 public class BatchActivityVerificationTest21 extends BatchActivityVerificationTest {
     public BatchActivityVerificationTest21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/batches/BatchPrimingTest21.java
+++ b/java-it-tests/driver21/src/test/java/batches/BatchPrimingTest21.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor21;
 
 public class BatchPrimingTest21 extends BatchPrimingTest {
     public BatchPrimingTest21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/cassandra/CassandraExecutor21.java
+++ b/java-it-tests/driver21/src/test/java/cassandra/CassandraExecutor21.java
@@ -28,7 +28,7 @@ public class CassandraExecutor21 implements CassandraExecutor {
     private Cluster cluster;
     private Session session;
 
-    public CassandraExecutor21() {
+    public CassandraExecutor21(int binaryPort) {
         NettyOptions closeQuickly = new NettyOptions() {
             public void onClusterClose(EventLoopGroup eventLoopGroup) {
                 //Shutdown immediately, since we close cluster when finished, we know nothing new coming through.
@@ -36,7 +36,7 @@ public class CassandraExecutor21 implements CassandraExecutor {
             }
         };
         cluster = Cluster.builder().addContactPoint(Config.NATIVE_HOST)
-                .withPort(Config.NATIVE_PORT)
+                .withPort(binaryPort)
                 .withNettyOptions(closeQuickly)
                 .build();
         session = cluster.connect(KEYSPACE);

--- a/java-it-tests/driver21/src/test/java/just21/MetaDataPriming21.java
+++ b/java-it-tests/driver21/src/test/java/just21/MetaDataPriming21.java
@@ -19,7 +19,6 @@ import com.datastax.driver.core.Cluster;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import common.AbstractScassandraTest;
-import common.Config;
 import org.junit.Test;
 import org.scassandra.http.client.ColumnTypes;
 import org.scassandra.http.client.PrimingRequest;
@@ -33,7 +32,7 @@ public class MetaDataPriming21 extends AbstractScassandraTest {
     public static final String CUSTOM_CLUSTER_NAME = "custom cluster name";
 
     public MetaDataPriming21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 
     @Test
@@ -57,7 +56,7 @@ public class MetaDataPriming21 extends AbstractScassandraTest {
 
         //when
         Cluster cluster = Cluster.builder().addContactPoint("localhost")
-                .withPort(Config.NATIVE_PORT).build();
+                .withPort(scassandra.getBinaryPort()).build();
         cluster.connect();
 
         //then

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementCollectionVariables21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementCollectionVariables21.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor21;
 public class PreparedStatementCollectionVariables21 extends PreparedStatementCollectionVariables {
 
     public PreparedStatementCollectionVariables21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementDelayTest21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementDelayTest21.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor21;
 
 public class PreparedStatementDelayTest21 extends PreparedStatementDelayTest {
     public PreparedStatementDelayTest21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementErrorPrimingTest21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementErrorPrimingTest21.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor21;
 public class PreparedStatementErrorPrimingTest21 extends PreparedStatementErrorPrimingTest {
 
     public PreparedStatementErrorPrimingTest21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementPreparationTest21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementPreparationTest21.java
@@ -5,7 +5,7 @@ import cassandra.CassandraExecutor21;
 public class PreparedStatementPreparationTest21 extends PreparedStatementPreparationTest {
 
     public PreparedStatementPreparationTest21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 
 }

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementPrimeOnVariablesTest21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementPrimeOnVariablesTest21.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor21;
 
 public class PreparedStatementPrimeOnVariablesTest21 extends PreparedStatementPrimeOnVariables {
     public PreparedStatementPrimeOnVariablesTest21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableTypes21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableTypes21.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor21;
 public class PreparedStatementPrimitiveVariableTypes21 extends PreparedStatementPrimitiveVariableTypes {
 
     public PreparedStatementPrimitiveVariableTypes21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableWithMatcherTypes21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableWithMatcherTypes21.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor21;
 
 public class PreparedStatementPrimitiveVariableWithMatcherTypes21 extends PreparedStatementPrimitiveVariableWithMatcherTypes {
     public PreparedStatementPrimitiveVariableWithMatcherTypes21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementTest21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementTest21.java
@@ -19,6 +19,6 @@ import cassandra.CassandraExecutor21;
 public class PreparedStatementTest21 extends PreparedStatementTest {
 
     public PreparedStatementTest21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementsListVariablesWithMatcher21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementsListVariablesWithMatcher21.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor21;
 
 public class PreparedStatementsListVariablesWithMatcher21 extends PreparedStatementsListVariablesWithMatcher {
     public PreparedStatementsListVariablesWithMatcher21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementsMapVariablesWithMatcher21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementsMapVariablesWithMatcher21.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor21;
 
 public class PreparedStatementsMapVariablesWithMatcher21 extends PreparedStatementsMapVariablesWithMatcher {
     public PreparedStatementsMapVariablesWithMatcher21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementsSetVariablesWithMatcher21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementsSetVariablesWithMatcher21.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor21;
 
 public class PreparedStatementsSetVariablesWithMatcher21 extends PreparedStatementsSetVariablesWithMatcher {
     public PreparedStatementsSetVariablesWithMatcher21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementsWithPattern21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementsWithPattern21.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor21;
 public class PreparedStatementsWithPattern21 extends PreparedStatementsWithPattern {
 
     public PreparedStatementsWithPattern21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/queries/BasicPrimingTest21.java
+++ b/java-it-tests/driver21/src/test/java/queries/BasicPrimingTest21.java
@@ -19,6 +19,6 @@ import cassandra.CassandraExecutor21;
 public class BasicPrimingTest21 extends BasicPrimingTest {
 
     public BasicPrimingTest21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/queries/DelayTest21.java
+++ b/java-it-tests/driver21/src/test/java/queries/DelayTest21.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor21;
 
 public class DelayTest21 extends DelayTest {
     public DelayTest21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/queries/PrimingCollectionsForQuery21.java
+++ b/java-it-tests/driver21/src/test/java/queries/PrimingCollectionsForQuery21.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor21;
 
 public class PrimingCollectionsForQuery21 extends PrimingMapsForQuery {
     public PrimingCollectionsForQuery21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/queries/PrimingListsForQuery21.java
+++ b/java-it-tests/driver21/src/test/java/queries/PrimingListsForQuery21.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor21;
 
 public class PrimingListsForQuery21 extends PrimingListsForQuery {
     public PrimingListsForQuery21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/queries/PrimingPrimitiveTypesForQuery21.java
+++ b/java-it-tests/driver21/src/test/java/queries/PrimingPrimitiveTypesForQuery21.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor21;
 public class PrimingPrimitiveTypesForQuery21 extends PrimingPrimitiveTypesForQuery {
 
     public PrimingPrimitiveTypesForQuery21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/queries/PrimingSetsForQuery21.java
+++ b/java-it-tests/driver21/src/test/java/queries/PrimingSetsForQuery21.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor21;
 
 public class PrimingSetsForQuery21 extends PrimingSetsForQuery {
     public PrimingSetsForQuery21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/queries/PrimingTimestamps21.java
+++ b/java-it-tests/driver21/src/test/java/queries/PrimingTimestamps21.java
@@ -19,6 +19,6 @@ import cassandra.CassandraExecutor21;
 public class PrimingTimestamps21 extends PrimingTimestamps {
 
     public PrimingTimestamps21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/queries/PrimingWithPattern21.java
+++ b/java-it-tests/driver21/src/test/java/queries/PrimingWithPattern21.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor21;
 public class PrimingWithPattern21 extends PrimingWithPattern {
 
     public PrimingWithPattern21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/queries/QueryBuilderTest21.java
+++ b/java-it-tests/driver21/src/test/java/queries/QueryBuilderTest21.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor21;
 
 public class QueryBuilderTest21 extends QueryBuilderTest {
     public QueryBuilderTest21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver21/src/test/java/queries/QueryErrorPrimingTest21.java
+++ b/java-it-tests/driver21/src/test/java/queries/QueryErrorPrimingTest21.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor21;
 public class QueryErrorPrimingTest21 extends QueryErrorPrimingTest {
 
     public QueryErrorPrimingTest21() {
-        super(new CassandraExecutor21());
+        super(new CassandraExecutor21(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/batches/BatchActivityVerificationTest30.java
+++ b/java-it-tests/driver30/src/test/java/batches/BatchActivityVerificationTest30.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor30;
 
 public class BatchActivityVerificationTest30 extends BatchActivityVerificationTest {
     public BatchActivityVerificationTest30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/batches/BatchPrimingTest30.java
+++ b/java-it-tests/driver30/src/test/java/batches/BatchPrimingTest30.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor30;
 
 public class BatchPrimingTest30 extends BatchPrimingTest {
     public BatchPrimingTest30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/cassandra/CassandraExecutor30.java
+++ b/java-it-tests/driver30/src/test/java/cassandra/CassandraExecutor30.java
@@ -28,7 +28,7 @@ public class CassandraExecutor30 implements CassandraExecutor {
     private Cluster cluster;
     private Session session;
 
-    public CassandraExecutor30() {
+    public CassandraExecutor30(int binaryPort) {
         NettyOptions closeQuickly = new NettyOptions() {
             public void onClusterClose(EventLoopGroup eventLoopGroup) {
                 //Shutdown immediately, since we close cluster when finished, we know nothing new coming through.
@@ -36,7 +36,7 @@ public class CassandraExecutor30 implements CassandraExecutor {
             }
         };
         cluster = Cluster.builder().addContactPoint(Config.NATIVE_HOST)
-                .withPort(Config.NATIVE_PORT)
+                .withPort(binaryPort)
                 .withQueryOptions(new QueryOptions().setConsistencyLevel(ConsistencyLevel.ONE))
                 .withNettyOptions(closeQuickly)
                 .build();

--- a/java-it-tests/driver30/src/test/java/just30/MetaDataPriming30.java
+++ b/java-it-tests/driver30/src/test/java/just30/MetaDataPriming30.java
@@ -19,7 +19,6 @@ import com.datastax.driver.core.Cluster;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import common.AbstractScassandraTest;
-import common.Config;
 import org.junit.Test;
 import org.scassandra.http.client.ColumnTypes;
 import org.scassandra.http.client.PrimingRequest;
@@ -33,7 +32,7 @@ public class MetaDataPriming30 extends AbstractScassandraTest {
     public static final String CUSTOM_CLUSTER_NAME = "custom cluster name";
 
     public MetaDataPriming30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 
     @Test
@@ -57,7 +56,7 @@ public class MetaDataPriming30 extends AbstractScassandraTest {
 
         //when
         Cluster cluster = Cluster.builder().addContactPoint("localhost")
-                .withPort(Config.NATIVE_PORT).build();
+                .withPort(scassandra.getBinaryPort()).build();
         cluster.connect();
 
         //then

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementCollectionVariables30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementCollectionVariables30.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor30;
 public class PreparedStatementCollectionVariables30 extends PreparedStatementCollectionVariables {
 
     public PreparedStatementCollectionVariables30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementDelayTest30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementDelayTest30.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor30;
 
 public class PreparedStatementDelayTest30 extends PreparedStatementDelayTest {
     public PreparedStatementDelayTest30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementErrorPrimingTest30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementErrorPrimingTest30.java
@@ -7,6 +7,6 @@ import org.junit.Ignore;
 public class PreparedStatementErrorPrimingTest30 extends PreparedStatementErrorPrimingTest {
 
     public PreparedStatementErrorPrimingTest30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementPreparationTest30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementPreparationTest30.java
@@ -5,7 +5,7 @@ import cassandra.CassandraExecutor30;
 public class PreparedStatementPreparationTest30 extends PreparedStatementPreparationTest {
 
     public PreparedStatementPreparationTest30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 
 }

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementPrimeOnVariablesTest30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementPrimeOnVariablesTest30.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor30;
 
 public class PreparedStatementPrimeOnVariablesTest30 extends PreparedStatementPrimeOnVariables {
     public PreparedStatementPrimeOnVariablesTest30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableTypes30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableTypes30.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor30;
 public class PreparedStatementPrimitiveVariableTypes30 extends PreparedStatementPrimitiveVariableTypes {
 
     public PreparedStatementPrimitiveVariableTypes30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableWithMatcherTypes30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableWithMatcherTypes30.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor30;
 
 public class PreparedStatementPrimitiveVariableWithMatcherTypes30 extends PreparedStatementPrimitiveVariableWithMatcherTypes {
     public PreparedStatementPrimitiveVariableWithMatcherTypes30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementTest30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementTest30.java
@@ -19,6 +19,6 @@ import cassandra.CassandraExecutor30;
 public class PreparedStatementTest30 extends PreparedStatementTest {
 
     public PreparedStatementTest30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementsListVariablesWithMatcher30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementsListVariablesWithMatcher30.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor30;
 
 public class PreparedStatementsListVariablesWithMatcher30 extends PreparedStatementsListVariablesWithMatcher {
     public PreparedStatementsListVariablesWithMatcher30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementsMapVariablesWithMatcher30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementsMapVariablesWithMatcher30.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor30;
 
 public class PreparedStatementsMapVariablesWithMatcher30 extends PreparedStatementsMapVariablesWithMatcher {
     public PreparedStatementsMapVariablesWithMatcher30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementsSetVariablesWithMatcher30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementsSetVariablesWithMatcher30.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor30;
 
 public class PreparedStatementsSetVariablesWithMatcher30 extends PreparedStatementsSetVariablesWithMatcher {
     public PreparedStatementsSetVariablesWithMatcher30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementsWithPattern30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementsWithPattern30.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor30;
 public class PreparedStatementsWithPattern30 extends PreparedStatementsWithPattern {
 
     public PreparedStatementsWithPattern30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/queries/BasicPrimingTest30.java
+++ b/java-it-tests/driver30/src/test/java/queries/BasicPrimingTest30.java
@@ -19,6 +19,6 @@ import cassandra.CassandraExecutor30;
 public class BasicPrimingTest30 extends BasicPrimingTest {
 
     public BasicPrimingTest30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/queries/DelayTest30.java
+++ b/java-it-tests/driver30/src/test/java/queries/DelayTest30.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor30;
 
 public class DelayTest30 extends DelayTest {
     public DelayTest30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/queries/PrimingCollectionsForQuery30.java
+++ b/java-it-tests/driver30/src/test/java/queries/PrimingCollectionsForQuery30.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor30;
 
 public class PrimingCollectionsForQuery30 extends PrimingMapsForQuery {
     public PrimingCollectionsForQuery30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/queries/PrimingListsForQuery30.java
+++ b/java-it-tests/driver30/src/test/java/queries/PrimingListsForQuery30.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor30;
 
 public class PrimingListsForQuery30 extends PrimingListsForQuery {
     public PrimingListsForQuery30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/queries/PrimingPrimitiveTypesForQuery30.java
+++ b/java-it-tests/driver30/src/test/java/queries/PrimingPrimitiveTypesForQuery30.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor30;
 public class PrimingPrimitiveTypesForQuery30 extends PrimingPrimitiveTypesForQuery {
 
     public PrimingPrimitiveTypesForQuery30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/queries/PrimingSetsForQuery30.java
+++ b/java-it-tests/driver30/src/test/java/queries/PrimingSetsForQuery30.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor30;
 
 public class PrimingSetsForQuery30 extends PrimingSetsForQuery {
     public PrimingSetsForQuery30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/queries/PrimingTimestamps30.java
+++ b/java-it-tests/driver30/src/test/java/queries/PrimingTimestamps30.java
@@ -19,6 +19,6 @@ import cassandra.CassandraExecutor30;
 public class PrimingTimestamps30 extends PrimingTimestamps {
 
     public PrimingTimestamps30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/queries/PrimingWithPattern30.java
+++ b/java-it-tests/driver30/src/test/java/queries/PrimingWithPattern30.java
@@ -5,6 +5,6 @@ import cassandra.CassandraExecutor30;
 public class PrimingWithPattern30 extends PrimingWithPattern {
 
     public PrimingWithPattern30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/queries/QueryBuilderTest30.java
+++ b/java-it-tests/driver30/src/test/java/queries/QueryBuilderTest30.java
@@ -4,6 +4,6 @@ import cassandra.CassandraExecutor30;
 
 public class QueryBuilderTest30 extends QueryBuilderTest {
     public QueryBuilderTest30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }

--- a/java-it-tests/driver30/src/test/java/queries/QueryErrorPrimingTest30.java
+++ b/java-it-tests/driver30/src/test/java/queries/QueryErrorPrimingTest30.java
@@ -6,6 +6,6 @@ import org.junit.Ignore;
 @Ignore
 public class QueryErrorPrimingTest30 extends QueryErrorPrimingTest {
     public QueryErrorPrimingTest30() {
-        super(new CassandraExecutor30());
+        super(new CassandraExecutor30(scassandra.getBinaryPort()));
     }
 }


### PR DESCRIPTION
This PR addresses #66 issue.

In order to execute them in parallel you need to add the params `--parallel --max-workers=4` to the following command:

```
./gradlew java-it-tests:common:check \
 java-it-tests:driver20:check java-it-tests:driver21:check java-it-tests:driver30:check \
 -x signArchives
```

This command takes `6 mins 34.436 secs` on my machine with bounded parallel execution. It takes `17 mins 33.088 secs` serially. 

A processors limit is included because Travis [states](https://docs.travis-ci.com/user/common-build-problems/#My-build-script-is-killed-without-any-error) that unbounded parallel builds could crash:

> Tests running in parallel using too many processes or threads (e.g. using the parallel_test gem)

I couldn't find any focused and small library to do the job of locating free ports. That's why I'm including `PortLocator` class.
