### PR TITLE
Fix to allow multiple test cases (files) to run sequentially (i.e. in Maven and Eclipse).

### DIFF
--- a/java-client/src/main/java/org/scassandra/junit/ScassandraServerRule.java
+++ b/java-client/src/main/java/org/scassandra/junit/ScassandraServerRule.java
@@ -53,6 +53,7 @@ public class ScassandraServerRule implements TestRule {
                         base.evaluate();
                     } finally {
                         scassandra.stop();
+                        started = false;
                     }
                 } else {
                     primingClient().clearAllPrimes();


### PR DESCRIPTION
I ran into a problem where I had several unit test files, all had a static @ClassRule ScassandraServerRule, but only the first one would pass. The subsequent ones would allow connections. This one line fixes this problem.