### PR TITLE
[#165] Update PortLocator to use OS to get port

### DIFF
--- a/java-it-tests/common/src/main/java/common/PortLocator.java
+++ b/java-it-tests/common/src/main/java/common/PortLocator.java
@@ -1,40 +1,30 @@
 package common;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
-import java.util.Random;
+import java.net.ServerSocket;
 
 public class PortLocator {
-    private static final int MIN_PORT = 1024;
-    private static final int MAX_PORT = 65535;
-    private static final int MAX_PORT_FAILURES = 10;
-    private static final int CONNECT_TIMEOUT_MS = 2000;
-    private static final Random random = new Random(System.currentTimeMillis());
 
     public static int findFreePort() {
-        for (int attempts = 1; attempts <= MAX_PORT_FAILURES; attempts++) {
-            int port = randomPort();
-            if (portFree(port)) {
-                return port;
-            }
-        }
-        throw new IllegalStateException("Not possible to find any free port");
-    }
-
-    private static int randomPort() {
-        int range = MAX_PORT - MIN_PORT;
-        return MIN_PORT + random.nextInt(range + 1);
-    }
-
-    private static boolean portFree(int port) {
+        ServerSocket socket = null;
         try {
-            Socket socket = new Socket();
-            socket.connect(new InetSocketAddress("localhost", port), CONNECT_TIMEOUT_MS);
-            socket.close();
-            return false;
+            // let the system pick an ephemeral port.
+            socket = new ServerSocket(0);
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
         } catch (IOException e) {
-            return true;
+            // throw as RuntimeException, this would be completely
+            // unexpected and we don't expect callers to have a
+            // strategy to handle this.
+            throw new RuntimeException(e);
+        } finally {
+            if (socket != null) {
+                try {
+                    socket.close();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Use new ServerSocket(0) to have OS provide an ephemeral port and return it.

Will run on travis a few times to see if it really fixes the issue or not, since I could not get the previous implementation to fail locally.