### PR TITLE
Update license headers and add validation to 'check'

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright (C) 2016 Christopher Batey and Dogan Narinc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,23 @@
 plugins {
     id 'net.researchgate.release' version '2.1.2'
+    id 'com.github.hierynomus.license' version '0.11.0'
 }
 apply plugin: 'java'
 apply plugin: 'scala'
 
 task wrapper(type: Wrapper) {
     gradleVersion = '2.5'
+}
+
+subprojects {
+    apply plugin: 'license'
+
+    license {
+        header rootProject.file('LICENSE')
+        strictCheck true
+        mapping {
+            java = 'SLASHSTAR_STYLE'
+            scala = 'SLASHSTAR_STYLE'
+        }
+    }
 }

--- a/java-client/src/main/java/org/scassandra/Scassandra.java
+++ b/java-client/src/main/java/org/scassandra/Scassandra.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/ScassandraFactory.java
+++ b/java-client/src/main/java/org/scassandra/ScassandraFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/ScassandraRunner.java
+++ b/java-client/src/main/java/org/scassandra/ScassandraRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/ActivityClient.java
+++ b/java-client/src/main/java/org/scassandra/http/client/ActivityClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/ActivityRequestFailed.java
+++ b/java-client/src/main/java/org/scassandra/http/client/ActivityRequestFailed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/AlreadyExistsConfig.java
+++ b/java-client/src/main/java/org/scassandra/http/client/AlreadyExistsConfig.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.http.client;
 
 import java.util.Map;

--- a/java-client/src/main/java/org/scassandra/http/client/BatchExecution.java
+++ b/java-client/src/main/java/org/scassandra/http/client/BatchExecution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/BatchPrimingRequest.java
+++ b/java-client/src/main/java/org/scassandra/http/client/BatchPrimingRequest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.http.client;
 
 import java.util.*;

--- a/java-client/src/main/java/org/scassandra/http/client/BatchQuery.java
+++ b/java-client/src/main/java/org/scassandra/http/client/BatchQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/BatchQueryKind.java
+++ b/java-client/src/main/java/org/scassandra/http/client/BatchQueryKind.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.http.client;
 
 public enum BatchQueryKind {

--- a/java-client/src/main/java/org/scassandra/http/client/BatchQueryPrime.java
+++ b/java-client/src/main/java/org/scassandra/http/client/BatchQueryPrime.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.http.client;
 
 /**

--- a/java-client/src/main/java/org/scassandra/http/client/BatchType.java
+++ b/java-client/src/main/java/org/scassandra/http/client/BatchType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/ClientConnection.java
+++ b/java-client/src/main/java/org/scassandra/http/client/ClientConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/ClosedConnectionConfig.java
+++ b/java-client/src/main/java/org/scassandra/http/client/ClosedConnectionConfig.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.http.client;
 
 import java.util.Map;

--- a/java-client/src/main/java/org/scassandra/http/client/ClosedConnectionReport.java
+++ b/java-client/src/main/java/org/scassandra/http/client/ClosedConnectionReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/ColumnTypes.java
+++ b/java-client/src/main/java/org/scassandra/http/client/ColumnTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/Config.java
+++ b/java-client/src/main/java/org/scassandra/http/client/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/Connection.java
+++ b/java-client/src/main/java/org/scassandra/http/client/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/ConnectionReport.java
+++ b/java-client/src/main/java/org/scassandra/http/client/ConnectionReport.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.http.client;
 
 import java.net.InetSocketAddress;

--- a/java-client/src/main/java/org/scassandra/http/client/ConnectionsRequestFailed.java
+++ b/java-client/src/main/java/org/scassandra/http/client/ConnectionsRequestFailed.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.http.client;
 
 public class ConnectionsRequestFailed extends RuntimeException {

--- a/java-client/src/main/java/org/scassandra/http/client/Consistency.java
+++ b/java-client/src/main/java/org/scassandra/http/client/Consistency.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.http.client;
 
 public enum Consistency {

--- a/java-client/src/main/java/org/scassandra/http/client/CurrentClient.java
+++ b/java-client/src/main/java/org/scassandra/http/client/CurrentClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/CurrentConnectionReport.java
+++ b/java-client/src/main/java/org/scassandra/http/client/CurrentConnectionReport.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.http.client;
 
 import java.net.InetSocketAddress;

--- a/java-client/src/main/java/org/scassandra/http/client/ErrorMessageConfig.java
+++ b/java-client/src/main/java/org/scassandra/http/client/ErrorMessageConfig.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.http.client;
 
 import java.util.Map;

--- a/java-client/src/main/java/org/scassandra/http/client/ListenerRequestFailed.java
+++ b/java-client/src/main/java/org/scassandra/http/client/ListenerRequestFailed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/MultiPrimeRequest.java
+++ b/java-client/src/main/java/org/scassandra/http/client/MultiPrimeRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/PreparedStatementExecution.java
+++ b/java-client/src/main/java/org/scassandra/http/client/PreparedStatementExecution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/PreparedStatementPreparation.java
+++ b/java-client/src/main/java/org/scassandra/http/client/PreparedStatementPreparation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/PrimeFailedException.java
+++ b/java-client/src/main/java/org/scassandra/http/client/PrimeFailedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/PrimingClient.java
+++ b/java-client/src/main/java/org/scassandra/http/client/PrimingClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/PrimingRequest.java
+++ b/java-client/src/main/java/org/scassandra/http/client/PrimingRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/Query.java
+++ b/java-client/src/main/java/org/scassandra/http/client/Query.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/ReadTimeoutConfig.java
+++ b/java-client/src/main/java/org/scassandra/http/client/ReadTimeoutConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/Result.java
+++ b/java-client/src/main/java/org/scassandra/http/client/Result.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.http.client;
 
 public enum Result {

--- a/java-client/src/main/java/org/scassandra/http/client/UnavailableConfig.java
+++ b/java-client/src/main/java/org/scassandra/http/client/UnavailableConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/UnpreparedConfig.java
+++ b/java-client/src/main/java/org/scassandra/http/client/UnpreparedConfig.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.http.client;
 
 import java.util.Map;

--- a/java-client/src/main/java/org/scassandra/http/client/WriteTimeoutConfig.java
+++ b/java-client/src/main/java/org/scassandra/http/client/WriteTimeoutConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/WriteTypePrime.java
+++ b/java-client/src/main/java/org/scassandra/http/client/WriteTypePrime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/types/ColumnMetadata.java
+++ b/java-client/src/main/java/org/scassandra/http/client/types/ColumnMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/types/GsonCqlTypeDeserialiser.java
+++ b/java-client/src/main/java/org/scassandra/http/client/types/GsonCqlTypeDeserialiser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/types/GsonCqlTypeSerialiser.java
+++ b/java-client/src/main/java/org/scassandra/http/client/types/GsonCqlTypeSerialiser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/types/GsonDateSerialiser.java
+++ b/java-client/src/main/java/org/scassandra/http/client/types/GsonDateSerialiser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/types/GsonExactMatchSerialiser.java
+++ b/java-client/src/main/java/org/scassandra/http/client/types/GsonExactMatchSerialiser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.http.client.types;
 
 import com.google.gson.*;

--- a/java-client/src/main/java/org/scassandra/http/client/types/GsonInetAddressSerialiser.java
+++ b/java-client/src/main/java/org/scassandra/http/client/types/GsonInetAddressSerialiser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/http/client/types/GsonVariableMatchDeserialiser.java
+++ b/java-client/src/main/java/org/scassandra/http/client/types/GsonVariableMatchDeserialiser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.http.client.types;
 
 import com.google.gson.*;

--- a/java-client/src/main/java/org/scassandra/junit/ScassandraServerRule.java
+++ b/java-client/src/main/java/org/scassandra/junit/ScassandraServerRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/matchers/Matchers.java
+++ b/java-client/src/main/java/org/scassandra/matchers/Matchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/matchers/PreparedStatementMatcher.java
+++ b/java-client/src/main/java/org/scassandra/matchers/PreparedStatementMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/matchers/QueryMatcher.java
+++ b/java-client/src/main/java/org/scassandra/matchers/QueryMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/main/java/org/scassandra/matchers/ScassandraMatcher.java
+++ b/java-client/src/main/java/org/scassandra/matchers/ScassandraMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/test/java/org/scassandra/VersionIntegrationTest.java
+++ b/java-client/src/test/java/org/scassandra/VersionIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/test/java/org/scassandra/http/client/ActivityClientTest.java
+++ b/java-client/src/test/java/org/scassandra/http/client/ActivityClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/test/java/org/scassandra/http/client/BatchExecutionTest.java
+++ b/java-client/src/test/java/org/scassandra/http/client/BatchExecutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/test/java/org/scassandra/http/client/BatchPrimingRequestTest.java
+++ b/java-client/src/test/java/org/scassandra/http/client/BatchPrimingRequestTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.http.client;
 
 import com.google.common.collect.ImmutableMap;

--- a/java-client/src/test/java/org/scassandra/http/client/BatchQueryTest.java
+++ b/java-client/src/test/java/org/scassandra/http/client/BatchQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/test/java/org/scassandra/http/client/ClientConnectionTest.java
+++ b/java-client/src/test/java/org/scassandra/http/client/ClientConnectionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.http.client;
 
 import nl.jqno.equalsverifier.EqualsVerifier;

--- a/java-client/src/test/java/org/scassandra/http/client/ConnectionTest.java
+++ b/java-client/src/test/java/org/scassandra/http/client/ConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/test/java/org/scassandra/http/client/CurrentClientTest.java
+++ b/java-client/src/test/java/org/scassandra/http/client/CurrentClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/test/java/org/scassandra/http/client/MultiPrimeRequestTest.java
+++ b/java-client/src/test/java/org/scassandra/http/client/MultiPrimeRequestTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.http.client;
 
 import nl.jqno.equalsverifier.EqualsVerifier;

--- a/java-client/src/test/java/org/scassandra/http/client/PreparedStatementExecutionTest.java
+++ b/java-client/src/test/java/org/scassandra/http/client/PreparedStatementExecutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/test/java/org/scassandra/http/client/PreparedStatementPreparationTest.java
+++ b/java-client/src/test/java/org/scassandra/http/client/PreparedStatementPreparationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/test/java/org/scassandra/http/client/PrimingClientTest.java
+++ b/java-client/src/test/java/org/scassandra/http/client/PrimingClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/test/java/org/scassandra/http/client/PrimingRequestTest.java
+++ b/java-client/src/test/java/org/scassandra/http/client/PrimingRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/test/java/org/scassandra/http/client/QueryTest.java
+++ b/java-client/src/test/java/org/scassandra/http/client/QueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/test/java/org/scassandra/http/client/types/GsonExactMatchSerialiserTest.java
+++ b/java-client/src/test/java/org/scassandra/http/client/types/GsonExactMatchSerialiserTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.http.client.types;
 
 import com.google.gson.Gson;

--- a/java-client/src/test/java/org/scassandra/http/client/types/GsonVariableMatchDeserialiserTest.java
+++ b/java-client/src/test/java/org/scassandra/http/client/types/GsonVariableMatchDeserialiserTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.http.client.types;
 
 import com.google.gson.Gson;

--- a/java-client/src/test/java/org/scassandra/integration/IntegrationTest.java
+++ b/java-client/src/test/java/org/scassandra/integration/IntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/test/java/org/scassandra/junit/ScassandraServerRuleTest.java
+++ b/java-client/src/test/java/org/scassandra/junit/ScassandraServerRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/test/java/org/scassandra/matchers/PreparedStatementMatcherTest.java
+++ b/java-client/src/test/java/org/scassandra/matchers/PreparedStatementMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/test/java/org/scassandra/matchers/QueryMatcherTest.java
+++ b/java-client/src/test/java/org/scassandra/matchers/QueryMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-client/src/test/resources/logback.xml
+++ b/java-client/src/test/resources/logback.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright (C) 2016 Christopher Batey and Dogan Narinc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <configuration>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">

--- a/java-it-tests/common/src/main/java/batches/BatchActivityVerificationTest.java
+++ b/java-it-tests/common/src/main/java/batches/BatchActivityVerificationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package batches;
 
 import com.google.common.collect.Lists;

--- a/java-it-tests/common/src/main/java/batches/BatchPrimingTest.java
+++ b/java-it-tests/common/src/main/java/batches/BatchPrimingTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package batches;/*
  * Copyright (C) 2014 Christopher Batey
  *

--- a/java-it-tests/common/src/main/java/common/AbstractScassandraTest.java
+++ b/java-it-tests/common/src/main/java/common/AbstractScassandraTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package common;
 
 import java.nio.ByteBuffer;

--- a/java-it-tests/common/src/main/java/common/CassandraExecutor.java
+++ b/java-it-tests/common/src/main/java/common/CassandraExecutor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package common;
 
 import com.google.common.base.Optional;

--- a/java-it-tests/common/src/main/java/common/CassandraQuery.java
+++ b/java-it-tests/common/src/main/java/common/CassandraQuery.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package common;
 
 public class CassandraQuery {

--- a/java-it-tests/common/src/main/java/common/CassandraResult.java
+++ b/java-it-tests/common/src/main/java/common/CassandraResult.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package common;
 
 import org.scassandra.http.client.Result;

--- a/java-it-tests/common/src/main/java/common/CassandraRow.java
+++ b/java-it-tests/common/src/main/java/common/CassandraRow.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package common;
 
 import com.google.common.collect.ImmutableMap;

--- a/java-it-tests/common/src/main/java/common/Config.java
+++ b/java-it-tests/common/src/main/java/common/Config.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package common;
 
 public class Config {

--- a/java-it-tests/common/src/main/java/common/PortLocator.java
+++ b/java-it-tests/common/src/main/java/common/PortLocator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package common;
 
 import java.io.IOException;

--- a/java-it-tests/common/src/main/java/common/WhereEquals.java
+++ b/java-it-tests/common/src/main/java/common/WhereEquals.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package common;
 
 public class WhereEquals<T> {

--- a/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementCollectionVariables.java
+++ b/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementCollectionVariables.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import com.google.common.collect.ImmutableMap;

--- a/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementDelayTest.java
+++ b/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementDelayTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import common.AbstractScassandraTest;

--- a/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementErrorPrimingTest.java
+++ b/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementErrorPrimingTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import common.*;

--- a/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementPreparationTest.java
+++ b/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementPreparationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import common.AbstractScassandraTest;

--- a/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementPrimeOnVariables.java
+++ b/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementPrimeOnVariables.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import com.google.common.base.Stopwatch;

--- a/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementPrimitiveVariableTypes.java
+++ b/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementPrimitiveVariableTypes.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import com.google.common.collect.ImmutableMap;

--- a/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementPrimitiveVariableWithMatcherTypes.java
+++ b/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementPrimitiveVariableWithMatcherTypes.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import com.google.common.collect.ImmutableMap;

--- a/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementTest.java
+++ b/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementTest.java
@@ -1,5 +1,5 @@
-package preparedstatements;/*
- * Copyright (C) 2014 Christopher Batey
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@ package preparedstatements;/*
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package preparedstatements;
 
 import com.google.common.collect.ImmutableMap;
 import common.AbstractScassandraTest;

--- a/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementsListVariablesWithMatcher.java
+++ b/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementsListVariablesWithMatcher.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import com.google.common.collect.ImmutableMap;

--- a/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementsMapVariablesWithMatcher.java
+++ b/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementsMapVariablesWithMatcher.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import com.google.common.collect.ImmutableMap;

--- a/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementsSetVariablesWithMatcher.java
+++ b/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementsSetVariablesWithMatcher.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import com.google.common.collect.ImmutableMap;

--- a/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementsWithPattern.java
+++ b/java-it-tests/common/src/main/java/preparedstatements/PreparedStatementsWithPattern.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import com.google.common.collect.ImmutableMap;

--- a/java-it-tests/common/src/main/java/queries/BasicPrimingTest.java
+++ b/java-it-tests/common/src/main/java/queries/BasicPrimingTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;/*
  * Copyright (C) 2014 Christopher Batey
  *

--- a/java-it-tests/common/src/main/java/queries/DelayTest.java
+++ b/java-it-tests/common/src/main/java/queries/DelayTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import common.AbstractScassandraTest;

--- a/java-it-tests/common/src/main/java/queries/PrimingListsForQuery.java
+++ b/java-it-tests/common/src/main/java/queries/PrimingListsForQuery.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import com.google.common.collect.ImmutableMap;

--- a/java-it-tests/common/src/main/java/queries/PrimingMapsForQuery.java
+++ b/java-it-tests/common/src/main/java/queries/PrimingMapsForQuery.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import com.google.common.collect.ImmutableMap;

--- a/java-it-tests/common/src/main/java/queries/PrimingPrimitiveTypesForQuery.java
+++ b/java-it-tests/common/src/main/java/queries/PrimingPrimitiveTypesForQuery.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import com.google.common.collect.ImmutableMap;

--- a/java-it-tests/common/src/main/java/queries/PrimingSetsForQuery.java
+++ b/java-it-tests/common/src/main/java/queries/PrimingSetsForQuery.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import com.google.common.collect.ImmutableMap;

--- a/java-it-tests/common/src/main/java/queries/PrimingTimestamps.java
+++ b/java-it-tests/common/src/main/java/queries/PrimingTimestamps.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;/*
  * Copyright (C) 2014 Christopher Batey
  *

--- a/java-it-tests/common/src/main/java/queries/PrimingWithPattern.java
+++ b/java-it-tests/common/src/main/java/queries/PrimingWithPattern.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import com.google.common.collect.ImmutableMap;

--- a/java-it-tests/common/src/main/java/queries/QueryBuilderTest.java
+++ b/java-it-tests/common/src/main/java/queries/QueryBuilderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import com.google.common.base.Optional;

--- a/java-it-tests/common/src/main/java/queries/QueryErrorPrimingTest.java
+++ b/java-it-tests/common/src/main/java/queries/QueryErrorPrimingTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import common.AbstractScassandraTest;

--- a/java-it-tests/driver20/src/test/java/batches/BatchActivityVerificationTest20.java
+++ b/java-it-tests/driver20/src/test/java/batches/BatchActivityVerificationTest20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package batches;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver20/src/test/java/batches/BatchPrimingTest20.java
+++ b/java-it-tests/driver20/src/test/java/batches/BatchPrimingTest20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package batches;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver20/src/test/java/cassandra/CassandraExecutor20.java
+++ b/java-it-tests/driver20/src/test/java/cassandra/CassandraExecutor20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cassandra;
 
 import java.net.InetSocketAddress;

--- a/java-it-tests/driver20/src/test/java/cassandra/CassandraResult20.java
+++ b/java-it-tests/driver20/src/test/java/cassandra/CassandraResult20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cassandra;
 
 import com.datastax.driver.core.ResultSet;

--- a/java-it-tests/driver20/src/test/java/cassandra/CassandraRow20.java
+++ b/java-it-tests/driver20/src/test/java/cassandra/CassandraRow20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cassandra;
 
 import com.datastax.driver.core.Row;

--- a/java-it-tests/driver20/src/test/java/just20/MetaDataPriming20.java
+++ b/java-it-tests/driver20/src/test/java/just20/MetaDataPriming20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package just20;/*
  * Copyright (C) 2014 Christopher Batey
  *

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementCollectionVariables20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementCollectionVariables20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementDelayTest20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementDelayTest20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementErrorPrimingTest20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementErrorPrimingTest20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementPreparationTest20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementPreparationTest20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementPrimeOnVariablesTest20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementPrimeOnVariablesTest20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableTypes20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableTypes20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableWithMatcherTypes20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableWithMatcherTypes20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementTest20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementTest20.java
@@ -1,5 +1,5 @@
-package preparedstatements;/*
- * Copyright (C) 2014 Christopher Batey
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@ package preparedstatements;/*
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package preparedstatements;
 
 import cassandra.CassandraExecutor20;
 

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementsListVariablesWithMatcher20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementsListVariablesWithMatcher20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementsMapVariablesWithMatcher20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementsMapVariablesWithMatcher20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementsSetVariablesWithMatcher20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementsSetVariablesWithMatcher20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementsWithPattern20.java
+++ b/java-it-tests/driver20/src/test/java/preparedstatements/PreparedStatementsWithPattern20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver20/src/test/java/queries/BasicPrimingTest20.java
+++ b/java-it-tests/driver20/src/test/java/queries/BasicPrimingTest20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;/*
  * Copyright (C) 2014 Christopher Batey
  *

--- a/java-it-tests/driver20/src/test/java/queries/DelayTest20.java
+++ b/java-it-tests/driver20/src/test/java/queries/DelayTest20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver20/src/test/java/queries/PrimingCollectionsForQuery20.java
+++ b/java-it-tests/driver20/src/test/java/queries/PrimingCollectionsForQuery20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 

--- a/java-it-tests/driver20/src/test/java/queries/PrimingListsForQuery20.java
+++ b/java-it-tests/driver20/src/test/java/queries/PrimingListsForQuery20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver20/src/test/java/queries/PrimingPrimitiveTypesForQuery20.java
+++ b/java-it-tests/driver20/src/test/java/queries/PrimingPrimitiveTypesForQuery20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver20/src/test/java/queries/PrimingSetsForQuery20.java
+++ b/java-it-tests/driver20/src/test/java/queries/PrimingSetsForQuery20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver20/src/test/java/queries/PrimingTimestamps20.java
+++ b/java-it-tests/driver20/src/test/java/queries/PrimingTimestamps20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;/*
  * Copyright (C) 2014 Christopher Batey
  *

--- a/java-it-tests/driver20/src/test/java/queries/PrimingWithPattern20.java
+++ b/java-it-tests/driver20/src/test/java/queries/PrimingWithPattern20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver20/src/test/java/queries/QueryBuilderTest20.java
+++ b/java-it-tests/driver20/src/test/java/queries/QueryBuilderTest20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver20/src/test/java/queries/QueryErrorPrimingTest20.java
+++ b/java-it-tests/driver20/src/test/java/queries/QueryErrorPrimingTest20.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor20;

--- a/java-it-tests/driver21/src/test/java/batches/BatchActivityVerificationTest21.java
+++ b/java-it-tests/driver21/src/test/java/batches/BatchActivityVerificationTest21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package batches;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/java/batches/BatchPrimingTest21.java
+++ b/java-it-tests/driver21/src/test/java/batches/BatchPrimingTest21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package batches;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/java/cassandra/CassandraExecutor21.java
+++ b/java-it-tests/driver21/src/test/java/cassandra/CassandraExecutor21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cassandra;
 
 import com.datastax.driver.core.*;

--- a/java-it-tests/driver21/src/test/java/cassandra/CassandraResult21.java
+++ b/java-it-tests/driver21/src/test/java/cassandra/CassandraResult21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cassandra;
 
 import com.datastax.driver.core.ResultSet;

--- a/java-it-tests/driver21/src/test/java/cassandra/CassandraRow21.java
+++ b/java-it-tests/driver21/src/test/java/cassandra/CassandraRow21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cassandra;
 
 import com.datastax.driver.core.Row;

--- a/java-it-tests/driver21/src/test/java/just21/MetaDataPriming21.java
+++ b/java-it-tests/driver21/src/test/java/just21/MetaDataPriming21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package just21;/*
  * Copyright (C) 2014 Christopher Batey
  *

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementCollectionVariables21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementCollectionVariables21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementDelayTest21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementDelayTest21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementErrorPrimingTest21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementErrorPrimingTest21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementPreparationTest21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementPreparationTest21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementPrimeOnVariablesTest21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementPrimeOnVariablesTest21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableTypes21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableTypes21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableWithMatcherTypes21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableWithMatcherTypes21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementTest21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementTest21.java
@@ -1,5 +1,5 @@
-package preparedstatements;/*
- * Copyright (C) 2014 Christopher Batey
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@ package preparedstatements;/*
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package preparedstatements;
 
 import cassandra.CassandraExecutor21;
 

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementsListVariablesWithMatcher21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementsListVariablesWithMatcher21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementsMapVariablesWithMatcher21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementsMapVariablesWithMatcher21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementsSetVariablesWithMatcher21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementsSetVariablesWithMatcher21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementsWithPattern21.java
+++ b/java-it-tests/driver21/src/test/java/preparedstatements/PreparedStatementsWithPattern21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/java/queries/BasicPrimingTest21.java
+++ b/java-it-tests/driver21/src/test/java/queries/BasicPrimingTest21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;/*
  * Copyright (C) 2014 Christopher Batey
  *

--- a/java-it-tests/driver21/src/test/java/queries/DelayTest21.java
+++ b/java-it-tests/driver21/src/test/java/queries/DelayTest21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/java/queries/PrimingCollectionsForQuery21.java
+++ b/java-it-tests/driver21/src/test/java/queries/PrimingCollectionsForQuery21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 

--- a/java-it-tests/driver21/src/test/java/queries/PrimingListsForQuery21.java
+++ b/java-it-tests/driver21/src/test/java/queries/PrimingListsForQuery21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/java/queries/PrimingPrimitiveTypesForQuery21.java
+++ b/java-it-tests/driver21/src/test/java/queries/PrimingPrimitiveTypesForQuery21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/java/queries/PrimingSetsForQuery21.java
+++ b/java-it-tests/driver21/src/test/java/queries/PrimingSetsForQuery21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/java/queries/PrimingTimestamps21.java
+++ b/java-it-tests/driver21/src/test/java/queries/PrimingTimestamps21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;/*
  * Copyright (C) 2014 Christopher Batey
  *

--- a/java-it-tests/driver21/src/test/java/queries/PrimingWithPattern21.java
+++ b/java-it-tests/driver21/src/test/java/queries/PrimingWithPattern21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/java/queries/QueryBuilderTest21.java
+++ b/java-it-tests/driver21/src/test/java/queries/QueryBuilderTest21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/java/queries/QueryErrorPrimingTest21.java
+++ b/java-it-tests/driver21/src/test/java/queries/QueryErrorPrimingTest21.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor21;

--- a/java-it-tests/driver21/src/test/resources/logback.xml
+++ b/java-it-tests/driver21/src/test/resources/logback.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright (C) 2016 Christopher Batey and Dogan Narinc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/java-it-tests/driver30/src/test/java/batches/BatchActivityVerificationTest30.java
+++ b/java-it-tests/driver30/src/test/java/batches/BatchActivityVerificationTest30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package batches;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/java/batches/BatchPrimingTest30.java
+++ b/java-it-tests/driver30/src/test/java/batches/BatchPrimingTest30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package batches;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/java/cassandra/CassandraExecutor30.java
+++ b/java-it-tests/driver30/src/test/java/cassandra/CassandraExecutor30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cassandra;
 
 import com.datastax.driver.core.*;

--- a/java-it-tests/driver30/src/test/java/cassandra/CassandraResult30.java
+++ b/java-it-tests/driver30/src/test/java/cassandra/CassandraResult30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cassandra;
 
 import com.datastax.driver.core.ResultSet;

--- a/java-it-tests/driver30/src/test/java/cassandra/CassandraRow30.java
+++ b/java-it-tests/driver30/src/test/java/cassandra/CassandraRow30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cassandra;
 
 import com.datastax.driver.core.Row;

--- a/java-it-tests/driver30/src/test/java/just30/MetaDataPriming30.java
+++ b/java-it-tests/driver30/src/test/java/just30/MetaDataPriming30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package just30;/*
  * Copyright (C) 2014 Christopher Batey
  *

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementCollectionVariables30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementCollectionVariables30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementDelayTest30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementDelayTest30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementErrorPrimingTest30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementErrorPrimingTest30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementPreparationTest30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementPreparationTest30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementPrimeOnVariablesTest30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementPrimeOnVariablesTest30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableTypes30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableTypes30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableWithMatcherTypes30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementPrimitiveVariableWithMatcherTypes30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementTest30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementTest30.java
@@ -1,5 +1,5 @@
-package preparedstatements;/*
- * Copyright (C) 2014 Christopher Batey
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@ package preparedstatements;/*
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package preparedstatements;
 
 import cassandra.CassandraExecutor30;
 

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementsListVariablesWithMatcher30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementsListVariablesWithMatcher30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementsMapVariablesWithMatcher30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementsMapVariablesWithMatcher30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementsSetVariablesWithMatcher30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementsSetVariablesWithMatcher30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementsWithPattern30.java
+++ b/java-it-tests/driver30/src/test/java/preparedstatements/PreparedStatementsWithPattern30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package preparedstatements;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/java/queries/BasicPrimingTest30.java
+++ b/java-it-tests/driver30/src/test/java/queries/BasicPrimingTest30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;/*
  * Copyright (C) 2014 Christopher Batey
  *

--- a/java-it-tests/driver30/src/test/java/queries/DelayTest30.java
+++ b/java-it-tests/driver30/src/test/java/queries/DelayTest30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/java/queries/PrimingCollectionsForQuery30.java
+++ b/java-it-tests/driver30/src/test/java/queries/PrimingCollectionsForQuery30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 

--- a/java-it-tests/driver30/src/test/java/queries/PrimingListsForQuery30.java
+++ b/java-it-tests/driver30/src/test/java/queries/PrimingListsForQuery30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/java/queries/PrimingPrimitiveTypesForQuery30.java
+++ b/java-it-tests/driver30/src/test/java/queries/PrimingPrimitiveTypesForQuery30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/java/queries/PrimingSetsForQuery30.java
+++ b/java-it-tests/driver30/src/test/java/queries/PrimingSetsForQuery30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/java/queries/PrimingTimestamps30.java
+++ b/java-it-tests/driver30/src/test/java/queries/PrimingTimestamps30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;/*
  * Copyright (C) 2014 Christopher Batey
  *

--- a/java-it-tests/driver30/src/test/java/queries/PrimingWithPattern30.java
+++ b/java-it-tests/driver30/src/test/java/queries/PrimingWithPattern30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/java/queries/QueryBuilderTest30.java
+++ b/java-it-tests/driver30/src/test/java/queries/QueryBuilderTest30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/java/queries/QueryErrorPrimingTest30.java
+++ b/java-it-tests/driver30/src/test/java/queries/QueryErrorPrimingTest30.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package queries;
 
 import cassandra.CassandraExecutor30;

--- a/java-it-tests/driver30/src/test/resources/logback.xml
+++ b/java-it-tests/driver30/src/test/resources/logback.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright (C) 2016 Christopher Batey and Dogan Narinc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright (C) 2016 Christopher Batey and Dogan Narinc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <configuration>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">

--- a/server/src/main/scala/org/scassandra/server/ScassandraConfig.scala
+++ b/server/src/main/scala/org/scassandra/server/ScassandraConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.scassandra.server
 
 import java.util.concurrent.TimeUnit

--- a/server/src/main/scala/org/scassandra/server/ScassandraServer.scala
+++ b/server/src/main/scala/org/scassandra/server/ScassandraServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/ServerReadyListener.scala
+++ b/server/src/main/scala/org/scassandra/server/ServerReadyListener.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.scassandra.server
 
 import akka.actor.{ActorRef, Actor}

--- a/server/src/main/scala/org/scassandra/server/ServerStubRunner.scala
+++ b/server/src/main/scala/org/scassandra/server/ServerStubRunner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/actors/BatchHandler.scala
+++ b/server/src/main/scala/org/scassandra/server/actors/BatchHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/actors/ConnectionHandler.scala
+++ b/server/src/main/scala/org/scassandra/server/actors/ConnectionHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/actors/ExecuteHandler.scala
+++ b/server/src/main/scala/org/scassandra/server/actors/ExecuteHandler.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.server.actors
 
 

--- a/server/src/main/scala/org/scassandra/server/actors/NativeProtocolMessageHandler.scala
+++ b/server/src/main/scala/org/scassandra/server/actors/NativeProtocolMessageHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/actors/OptionsHandler.scala
+++ b/server/src/main/scala/org/scassandra/server/actors/OptionsHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/actors/PrepareHandler.scala
+++ b/server/src/main/scala/org/scassandra/server/actors/PrepareHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/actors/QueryHandler.scala
+++ b/server/src/main/scala/org/scassandra/server/actors/QueryHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/actors/RegisterHandler.scala
+++ b/server/src/main/scala/org/scassandra/server/actors/RegisterHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/actors/TcpConnectionWrapper.scala
+++ b/server/src/main/scala/org/scassandra/server/actors/TcpConnectionWrapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/actors/TcpServer.scala
+++ b/server/src/main/scala/org/scassandra/server/actors/TcpServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/AbstractMessageFactory.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/AbstractMessageFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/BatchQueryKind.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/BatchQueryKind.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.server.cqlmessages
 
 sealed abstract class BatchQueryKind {

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/BatchType.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/BatchType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/Consistency.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/Consistency.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/CqlMessage.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/CqlMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/CqlMessageFactory.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/CqlMessageFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/CqlProtocolHelper.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/CqlProtocolHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/Header.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/Header.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/OpCodes.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/OpCodes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/ProtocolVersion.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/ProtocolVersion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/VersionOneMessageFactory.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/VersionOneMessageFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/VersionTwoMessageFactory.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/VersionTwoMessageFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/request/ExecuteRequest.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/request/ExecuteRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/request/Request.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/request/Request.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/response/Error.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/response/Error.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/response/PreparedResult.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/response/PreparedResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/response/Response.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/response/Response.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/response/ResponseDeserializer.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/response/ResponseDeserializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/response/Result.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/response/Result.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/response/ResultHelper.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/response/ResultHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/response/ResultKinds.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/response/ResultKinds.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/response/Rows.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/response/Rows.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/response/RowsFlagParser.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/response/RowsFlagParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/ColumnType.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/ColumnType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlAscii.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlAscii.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlBigint.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlBigint.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlBlob.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlBlob.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlBoolean.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlBoolean.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlCounter.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlCounter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlDecimal.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlDecimal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlDouble.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlDouble.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlFloat.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlFloat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlInet.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlInet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlInt.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlInt.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlList.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlList.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlLongType.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlLongType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlMap.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlMap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlSet.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlSet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlText.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlText.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlTextType.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlTextType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlTimeUUID.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlTimeUUID.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlTimestamp.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlTimestamp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlUUID.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlUUID.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlUUIDType.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlUUIDType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlVarchar.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlVarchar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlVarint.scala
+++ b/server/src/main/scala/org/scassandra/server/cqlmessages/types/CqlVarint.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/ActivityLog.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/ActivityLog.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/Defaulter.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/Defaulter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/ErrorConstants.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/ErrorConstants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/PrimeResult.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/PrimeResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/PrimeValidator.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/PrimeValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/PrimingServer.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/PrimingServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/batch/BatchPrimeSingle.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/batch/BatchPrimeSingle.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.server.priming.batch
 
 import org.scassandra.server.cqlmessages.{BatchType, Consistency, BatchQueryKind}

--- a/server/src/main/scala/org/scassandra/server/priming/batch/PrimeBatchStore.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/batch/PrimeBatchStore.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.server.priming.batch
 
 import com.typesafe.scalalogging.LazyLogging

--- a/server/src/main/scala/org/scassandra/server/priming/cors/CorsSupport.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/cors/CorsSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/json/PrimingJsonImplicits.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/json/PrimingJsonImplicits.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.server.priming.json
 
 import java.math.BigInteger

--- a/server/src/main/scala/org/scassandra/server/priming/json/ResultJsonRepresentation.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/json/ResultJsonRepresentation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/prepared/CompositePreparedPrimeStore.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/prepared/CompositePreparedPrimeStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/prepared/PreparedPrime.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/prepared/PreparedPrime.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/prepared/PreparedStore.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/prepared/PreparedStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/prepared/PrimePrepared.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/prepared/PrimePrepared.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/prepared/PrimePreparedMultiStore.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/prepared/PrimePreparedMultiStore.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.server.priming.prepared
 
 import java.util.concurrent.TimeUnit

--- a/server/src/main/scala/org/scassandra/server/priming/prepared/PrimePreparedPatternStore.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/prepared/PrimePreparedPatternStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/prepared/PrimePreparedStore.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/prepared/PrimePreparedStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/query/PrimeQuerySingle.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/query/PrimeQuerySingle.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/query/PrimeQueryStore.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/query/PrimeQueryStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/routes/ActivityVerificationRoute.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/routes/ActivityVerificationRoute.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/routes/CurrentRoute.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/routes/CurrentRoute.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/routes/PrimingBatchRoute.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/routes/PrimingBatchRoute.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.server.priming.routes
 
 import com.typesafe.scalalogging.LazyLogging

--- a/server/src/main/scala/org/scassandra/server/priming/routes/PrimingJsonHelper.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/routes/PrimingJsonHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/routes/PrimingPreparedRoute.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/routes/PrimingPreparedRoute.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/routes/PrimingQueryRoute.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/routes/PrimingQueryRoute.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/scala/org/scassandra/server/priming/routes/VersionRoute.scala
+++ b/server/src/main/scala/org/scassandra/server/priming/routes/VersionRoute.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/resources/logback.xml
+++ b/server/src/test/resources/logback.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright (C) 2016 Christopher Batey and Dogan Narinc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <configuration>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">

--- a/server/src/test/scala/org/scassandra/server/AbstractIntegrationTest.scala
+++ b/server/src/test/scala/org/scassandra/server/AbstractIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/JavaDriverIntegrationTest.scala
+++ b/server/src/test/scala/org/scassandra/server/JavaDriverIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/ServerReadyListenerTest.scala
+++ b/server/src/test/scala/org/scassandra/server/ServerReadyListenerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/ServerStubRunnerIntegrationTest.scala
+++ b/server/src/test/scala/org/scassandra/server/ServerStubRunnerIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/actors/BatchHandlerTest.scala
+++ b/server/src/test/scala/org/scassandra/server/actors/BatchHandlerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/actors/ConnectionHandlerTest.scala
+++ b/server/src/test/scala/org/scassandra/server/actors/ConnectionHandlerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/actors/ErrorHandlingBehaviors.scala
+++ b/server/src/test/scala/org/scassandra/server/actors/ErrorHandlingBehaviors.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.server.actors
 
 import org.scalatest.FunSuite

--- a/server/src/test/scala/org/scassandra/server/actors/ExecuteHandlerTest.scala
+++ b/server/src/test/scala/org/scassandra/server/actors/ExecuteHandlerTest.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.server.actors
 
 import java.util.concurrent.TimeUnit

--- a/server/src/test/scala/org/scassandra/server/actors/FatalHandlingBehaviors.scala
+++ b/server/src/test/scala/org/scassandra/server/actors/FatalHandlingBehaviors.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.server.actors
 
 import akka.io.Tcp

--- a/server/src/test/scala/org/scassandra/server/actors/MessageHelper.scala
+++ b/server/src/test/scala/org/scassandra/server/actors/MessageHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/actors/NativeProtocolMessageHandlerTest.scala
+++ b/server/src/test/scala/org/scassandra/server/actors/NativeProtocolMessageHandlerTest.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.server.actors
 
 import akka.actor.{ActorRef, ActorSystem}

--- a/server/src/test/scala/org/scassandra/server/actors/OptionsHandlerTest.scala
+++ b/server/src/test/scala/org/scassandra/server/actors/OptionsHandlerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/actors/PrepareHandlerTest.scala
+++ b/server/src/test/scala/org/scassandra/server/actors/PrepareHandlerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/actors/QueryFlagParser$Test.scala
+++ b/server/src/test/scala/org/scassandra/server/actors/QueryFlagParser$Test.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/actors/QueryHandlerTest.scala
+++ b/server/src/test/scala/org/scassandra/server/actors/QueryHandlerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/actors/RegisterHandlerTest.scala
+++ b/server/src/test/scala/org/scassandra/server/actors/RegisterHandlerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/actors/TcpConnectionWrapperTest.scala
+++ b/server/src/test/scala/org/scassandra/server/actors/TcpConnectionWrapperTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/actors/TcpServerReadyTest.scala
+++ b/server/src/test/scala/org/scassandra/server/actors/TcpServerReadyTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/actors/TcpServerTest.scala
+++ b/server/src/test/scala/org/scassandra/server/actors/TcpServerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cors/CorsSupportTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cors/CorsSupportTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/ConsistencyTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/ConsistencyTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/CqlProtocolHelperTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/CqlProtocolHelperTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/HeaderTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/HeaderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/ProtocolProvider.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/ProtocolProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/ProtocolVersionsTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/ProtocolVersionsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/VersionOneMessageFactoryTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/VersionOneMessageFactoryTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/VersionTwoMessageFactoryTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/VersionTwoMessageFactoryTest.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.server.cqlmessages
 
 import akka.util.{ByteIterator, ByteString}

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/request/ExecuteRequestTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/request/ExecuteRequestTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/request/RequestTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/request/RequestTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/response/ErrorTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/response/ErrorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/response/PreparedResultTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/response/PreparedResultTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/response/ResponseDeserializerTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/response/ResponseDeserializerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/response/ResponseTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/response/ResponseTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/response/ResultHelperTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/response/ResultHelperTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/response/ResultTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/response/ResultTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/response/RowsFlagParserTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/response/RowsFlagParserTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/response/RowsResponseTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/response/RowsResponseTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/response/RowsTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/response/RowsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/ColumnTypeTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/ColumnTypeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlAsciiTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlAsciiTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlBigintTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlBigintTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlBlobTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlBlobTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlBooleanTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlBooleanTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlCounterTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlCounterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlDecimalTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlDecimalTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlDoubleTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlDoubleTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlFloatTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlFloatTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlInetTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlInetTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlIntTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlIntTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlListTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlListTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlMapTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlMapTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlSetTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlSetTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlTextTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlTextTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlTimeUUIDTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlTimeUUIDTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlTimestampTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlTimestampTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlUUIDTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlUUIDTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlVarcharTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlVarcharTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlVarintTest.scala
+++ b/server/src/test/scala/org/scassandra/server/cqlmessages/types/CqlVarintTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/CurrentTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/CurrentTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/MetaDataTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/MetaDataTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/PreparedStatementPreparationVerificationTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/PreparedStatementPreparationVerificationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/prepared/PatternMatchingTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/prepared/PatternMatchingTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/prepared/PreparedStatementErrorsTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/prepared/PreparedStatementErrorsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/prepared/PreparedStatementWithCollectionsTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/prepared/PreparedStatementWithCollectionsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/prepared/PreparedStatementWithListsTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/prepared/PreparedStatementWithListsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/prepared/PreparedStatementWithSetsTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/prepared/PreparedStatementWithSetsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/prepared/PreparedStatementsTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/prepared/PreparedStatementsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/prepared/delays/PreparedStatementBasicDelaysTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/prepared/delays/PreparedStatementBasicDelaysTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/query/AdvancedPrimeCriteriaTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/query/AdvancedPrimeCriteriaTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/query/BasicPrimingTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/query/BasicPrimingTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/query/ListPriming.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/query/ListPriming.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/query/MapPriming.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/query/MapPriming.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/query/PatternMatchingTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/query/PatternMatchingTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/query/PrimingCqlTypesTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/query/PrimingCqlTypesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/query/PrimingErrorsTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/query/PrimingErrorsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/query/PrimingOptionalFieldsTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/query/PrimingOptionalFieldsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/query/SetPriming.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/query/SetPriming.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/query/delays/BasicDelaysPrimingTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/query/delays/BasicDelaysPrimingTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/querybuilder/QueryWithParametersTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/querybuilder/QueryWithParametersTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/verification/BatchVerificationTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/verification/BatchVerificationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/verification/ConnectionVerificationTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/verification/ConnectionVerificationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/verification/HeartbeatVerificationTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/verification/HeartbeatVerificationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/verification/PreparedStatementExecutionVerificationTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/verification/PreparedStatementExecutionVerificationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/e2e/verification/QueryVerificationTest.scala
+++ b/server/src/test/scala/org/scassandra/server/e2e/verification/QueryVerificationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/priming/ActivityLogTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/ActivityLogTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/priming/AnyJsonFormatTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/AnyJsonFormatTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/priming/ColumnTypeJsonFormatTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/ColumnTypeJsonFormatTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/priming/PrimeQueryStoreTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/PrimeQueryStoreTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/priming/PrimingServerReadyTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/PrimingServerReadyTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/priming/batch/PrimeBatchStoreTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/batch/PrimeBatchStoreTest.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.server.priming.batch
 
 import org.scalatest.{FunSpec, Matchers}

--- a/server/src/test/scala/org/scassandra/server/priming/prepared/CompositePreparedPrimeStoreTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/prepared/CompositePreparedPrimeStoreTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/priming/prepared/PrimePreparedMultiStoreTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/prepared/PrimePreparedMultiStoreTest.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.server.priming.prepared
 
 import java.util.concurrent.TimeUnit

--- a/server/src/test/scala/org/scassandra/server/priming/prepared/PrimePreparedPatternStoreTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/prepared/PrimePreparedPatternStoreTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/priming/prepared/PrimePreparedStoreTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/prepared/PrimePreparedStoreTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/priming/routes/ActivityVerificationRouteTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/routes/ActivityVerificationRouteTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/priming/routes/CurrentRouteTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/routes/CurrentRouteTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/priming/routes/PrimingBatchRouteTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/routes/PrimingBatchRouteTest.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.server.priming.routes
 
 import org.mockito.Mockito._

--- a/server/src/test/scala/org/scassandra/server/priming/routes/PrimingJsonHelperTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/routes/PrimingJsonHelperTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/priming/routes/PrimingPreparedRouteTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/routes/PrimingPreparedRouteTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/priming/routes/PrimingQueryRouteTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/routes/PrimingQueryRouteTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/scala/org/scassandra/server/priming/routes/VersionRouteTest.scala
+++ b/server/src/test/scala/org/scassandra/server/priming/routes/VersionRouteTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Christopher Batey and Dogan Narinc
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Ahead of the incoming PR for #76 , I thought it would be good to add [license-gradle-plugin](https://github.com/hierynomus/license-gradle-plugin) for adding, updating and validating license header presence in all source files.

License validation will be done automatically as part of the check task.  The build will fail if the header is missing from any file.

To update all files with the `LICENSE` header, simply run:

`./gradlew licenseFormat`

See 	b4d046a for the gradle changes specifically.