### PR TITLE
[#173] Migrate cql-antlr from its own repo to a submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ _site
 *.iml
 build
 docs/site
+classes
+**/src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -19,5 +19,24 @@ subprojects {
             java = 'SLASHSTAR_STYLE'
             scala = 'SLASHSTAR_STYLE'
         }
+        // Excluded generated antlr code
+        exclude '**/CqlTypes*.java'
+    }
+
+    ext {
+        antlrVersion = '4.5'
+        akkaVersion = '2.3.9'
+        commonsCodecVersion = '1.10'
+        httpClientVersion = '4.3.3'
+        javaDriverVersion = '2.0.10'
+        junitVersion = '4.11'
+        guavaVersion = '17.0'
+        gsonVersion = '2.5'
+        logbackVersion = '1.1.1'
+        mockitoVersion = '1.9.5'
+        scalaVersion = '2.11.7'
+        slf4jVersion = '1.7.10'
+        sprayVersion = '1.3.3'
+        sprayJsonVersion = '1.3.2'
     }
 }

--- a/cql-antlr/build.gradle
+++ b/cql-antlr/build.gradle
@@ -1,0 +1,152 @@
+apply plugin: 'java'
+apply plugin: 'idea'
+apply plugin: 'signing'
+apply plugin: 'maven'
+
+buildscript {
+    repositories {
+        jcenter()
+        maven {
+            name 'JFrog OSS snapshot repo'
+            url  'https://oss.jfrog.org/oss-snapshot-local/'
+        }
+        mavenCentral()
+        maven { url "https://oss.sonatype.org/content/groups/public"}
+
+    }
+    dependencies {
+        classpath 'com.github.townsfolk:gradle-release:1.2'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.0'
+        classpath 'me.champeau.gradle:antlr4-gradle-plugin:0.1'
+    }
+}
+
+apply plugin: 'me.champeau.gradle.antlr4'
+apply plugin: 'com.github.johnrengelman.shadow'
+apply plugin: 'release'
+
+createReleaseTag.dependsOn uploadArchives
+group 'org.scassandra'
+jar.baseName = 'cql-antlr'
+
+compileJava {
+    sourceCompatibility = "1.6"
+    targetCompatibility = "1.6"
+}
+
+if (!project.hasProperty("ossrhUsername")) {
+    ext.ossrhUsername = "dummy"
+}
+if (!project.hasProperty("ossrhPassword")) {
+    ext.ossrhPassword = "dummy"
+}
+
+task javadocJar(type: Jar) {
+    classifier = 'javadoc'
+    from javadoc
+}
+
+task sourceJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+artifacts {
+    archives jar
+    archives javadocJar
+    archives sourceJar
+}
+
+signing {
+    sign configurations.archives
+}
+
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(userName: ossrhUsername, password: ossrhPassword)
+            }
+
+            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots") {
+                authentication(userName: ossrhUsername, password: ossrhPassword)
+            }
+            pom.artifactId = 'cql-antlr'
+
+            pom.project {
+                name 'Scassandra CQL antlr'
+                packaging 'jar'
+                // optionally artifactId can be defined here
+                description 'CQL Types'
+                url 'https://github.com/chbatey/cql-antlr'
+
+                scm {
+                    connection 'scm:git:git@github.com:chbatey/cql-antlr.git'
+                    developerConnection 'git@github.com:chbatey/cql-antlr.git'
+                    url 'https://github.com/chbatey/cql-antlr'
+                }
+
+                licenses {
+                    license {
+                        name 'The Apache Software License, Version 2.0'
+                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id 'chbatey'
+                        name 'Christopher Batey'
+                        email 'christopher.batey@gmail.com'
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+    maven {
+        url "https://oss.sonatype.org/content/repositories/snapshots"
+    }
+    maven {
+        url "https://oss.sonatype.org/content/groups/staging"
+    }
+}
+
+
+dependencies {
+    compile 'org.antlr:antlr4-runtime:4.5'
+    compile 'org.slf4j:slf4j-api:1.7.10'
+    compile 'commons-codec:commons-codec:1.10'
+    compile 'com.google.guava:guava:17.0'
+    testCompile 'ch.qos.logback:logback-classic:1.1.1'
+    testCompile 'org.mockito:mockito-all:1.9.5'
+    testCompile 'junit:junit:4.11'
+}
+
+task wrapper(type: Wrapper) {
+    gradleVersion = '2.2.1'
+}
+
+antlr4 {
+    output = new File('src/main/generated/org/scassandra/antlr4')
+    extraArgs = ['-package', 'org.scassandra.antlr4']
+}
+
+// make the Java compile task depend on the antlr4 task
+compileJava.dependsOn antlr4
+
+// add the generated source files to the list of java sources
+sourceSets.main.java.srcDirs += 'src/main/generated'
+
+// add antlr4 to classpath
+configurations {
+    compile.extendsFrom antlr4
+}

--- a/cql-antlr/build.gradle
+++ b/cql-antlr/build.gradle
@@ -5,27 +5,22 @@ apply plugin: 'maven'
 
 buildscript {
     repositories {
-        jcenter()
-        maven {
-            name 'JFrog OSS snapshot repo'
-            url  'https://oss.jfrog.org/oss-snapshot-local/'
-        }
         mavenCentral()
-        maven { url "https://oss.sonatype.org/content/groups/public"}
-
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+        maven { url "https://oss.sonatype.org/content/groups/public" }
     }
     dependencies {
-        classpath 'com.github.townsfolk:gradle-release:1.2'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.0'
         classpath 'me.champeau.gradle:antlr4-gradle-plugin:0.1'
     }
 }
 
 apply plugin: 'me.champeau.gradle.antlr4'
-apply plugin: 'com.github.johnrengelman.shadow'
-apply plugin: 'release'
+apply plugin: 'java'
+apply plugin: 'signing'
+apply plugin: 'maven'
 
-createReleaseTag.dependsOn uploadArchives
 group 'org.scassandra'
 jar.baseName = 'cql-antlr'
 
@@ -39,6 +34,16 @@ if (!project.hasProperty("ossrhUsername")) {
 }
 if (!project.hasProperty("ossrhPassword")) {
     ext.ossrhPassword = "dummy"
+}
+
+repositories {
+    mavenCentral()
+    maven {
+        url "https://oss.sonatype.org/content/repositories/snapshots"
+    }
+    maven {
+        url "https://oss.sonatype.org/content/groups/staging"
+    }
 }
 
 task javadocJar(type: Jar) {
@@ -84,9 +89,9 @@ uploadArchives {
                 url 'https://github.com/chbatey/cql-antlr'
 
                 scm {
-                    connection 'scm:git:git@github.com:chbatey/cql-antlr.git'
-                    developerConnection 'git@github.com:chbatey/cql-antlr.git'
-                    url 'https://github.com/chbatey/cql-antlr'
+                    connection 'scm:git:git@github.com:scassandra/scassandra-server.git'
+                    developerConnection 'git@github.com:scassandra/scassandra-server.git'
+                    url 'https://github.com/scassandra/scassandra-server'
                 }
 
                 licenses {
@@ -108,31 +113,14 @@ uploadArchives {
     }
 }
 
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-    maven {
-        url "https://oss.sonatype.org/content/repositories/snapshots"
-    }
-    maven {
-        url "https://oss.sonatype.org/content/groups/staging"
-    }
-}
-
-
 dependencies {
-    compile 'org.antlr:antlr4-runtime:4.5'
-    compile 'org.slf4j:slf4j-api:1.7.10'
-    compile 'commons-codec:commons-codec:1.10'
-    compile 'com.google.guava:guava:17.0'
-    testCompile 'ch.qos.logback:logback-classic:1.1.1'
-    testCompile 'org.mockito:mockito-all:1.9.5'
-    testCompile 'junit:junit:4.11'
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.2.1'
+    compile "org.antlr:antlr4-runtime:$antlrVersion"
+    compile "org.slf4j:slf4j-api:$slf4jVersion"
+    compile "commons-codec:commons-codec:$commonsCodecVersion"
+    compile "com.google.guava:guava:$guavaVersion"
+    testCompile "ch.qos.logback:logback-classic:$logbackVersion"
+    testCompile "org.mockito:mockito-all:$mockitoVersion"
+    testCompile "junit:junit:$junitVersion"
 }
 
 antlr4 {
@@ -140,8 +128,16 @@ antlr4 {
     extraArgs = ['-package', 'org.scassandra.antlr4']
 }
 
+task licenseFormatGenerated (type:nl.javadude.gradle.plugins.license.License) {
+    source = fileTree(dir: "src/main/generated").include("**/*.java")
+}
+
+licenseFormatGenerated.dependsOn antlr4
+
 // make the Java compile task depend on the antlr4 task
 compileJava.dependsOn antlr4
+compileJava.dependsOn licenseFormatGenerated
+
 
 // add the generated source files to the list of java sources
 sourceSets.main.java.srcDirs += 'src/main/generated'

--- a/cql-antlr/src/main/antlr4/CqlTypes.g4
+++ b/cql-antlr/src/main/antlr4/CqlTypes.g4
@@ -1,0 +1,44 @@
+grammar CqlTypes;
+
+options {
+    language = Java;
+}
+
+data_type
+    : native_type
+    | list_type
+    | set_type
+    | map_type
+    ;
+
+
+native_type
+    : 'ascii'
+    | 'bigint'
+    | 'blob'
+    | 'boolean'
+    | 'counter'
+    | 'decimal'
+    | 'double'
+    | 'float'
+    | 'inet'
+    | 'int'
+    | 'text'
+    | 'timestamp'
+    | 'timeuuid'
+    | 'uuid'
+    | 'varchar'
+    | 'varint'
+    ;
+
+list_type
+    : 'list' '<' native_type '>'
+    ;
+
+set_type
+    : 'set' '<' native_type '>'
+    ;
+
+map_type
+    : 'map' '<' native_type ',' native_type '>'
+    ;

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlAscii.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlAscii.java
@@ -1,0 +1,13 @@
+package org.scassandra.cql;
+
+public class CqlAscii extends PrimitiveType {
+    CqlAscii() {
+        super("ascii");
+    }
+
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        if (expected == null) return actual == null;
+        return expected.equals(actual);
+    }
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlAscii.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlAscii.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 public class CqlAscii extends PrimitiveType {

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlBigInt.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlBigInt.java
@@ -1,0 +1,11 @@
+package org.scassandra.cql;
+
+public class CqlBigInt extends PrimitiveType {
+    CqlBigInt() {
+        super("bigint");
+    }
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        return equalsForLongType(expected, actual, this);
+    }
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlBigInt.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlBigInt.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 public class CqlBigInt extends PrimitiveType {

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlBlob.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlBlob.java
@@ -1,0 +1,29 @@
+package org.scassandra.cql;
+
+import org.apache.commons.codec.binary.Hex;
+
+import java.nio.ByteBuffer;
+
+public class CqlBlob extends PrimitiveType {
+    CqlBlob() {
+        super("blob");
+    }
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        if (expected == null) {
+            throw throwNullError(actual, this);
+        }
+        if (expected instanceof String) {
+            return expected.equals(actual);
+        } else if (expected instanceof ByteBuffer) {
+            ByteBuffer bb = (ByteBuffer) expected;
+            byte[] b = new byte[bb.remaining()];
+            bb.get(b);
+            String encodedExpected = Hex.encodeHexString(b);
+            String actualWithout0x = actual.toString().replaceFirst("0x", "");
+            return encodedExpected.equals(actualWithout0x);
+        } else {
+            throw throwInvalidType(expected, actual, this);
+        }
+    }
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlBlob.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlBlob.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 import org.apache.commons.codec.binary.Hex;

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlBoolean.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlBoolean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 public class CqlBoolean extends PrimitiveType {

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlBoolean.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlBoolean.java
@@ -1,0 +1,24 @@
+package org.scassandra.cql;
+
+public class CqlBoolean extends PrimitiveType {
+    CqlBoolean() {
+        super("boolean");
+    }
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        if (expected == null) throw throwNullError(actual, this);
+
+        Boolean actualTyped;
+        if (actual instanceof Boolean) {
+            actualTyped = (Boolean) actual;
+        } else {
+            actualTyped = Boolean.parseBoolean(actual.toString());
+        }
+
+        if (expected instanceof Boolean) {
+            return expected.equals(actualTyped);
+        } else {
+            throw throwInvalidType(expected, actual, this);
+        }
+    }
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlCounter.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlCounter.java
@@ -1,0 +1,11 @@
+package org.scassandra.cql;
+
+public class CqlCounter extends PrimitiveType {
+    CqlCounter() {
+        super("counter");
+    }
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        return equalsForLongType(expected, actual, this);
+    }
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlCounter.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlCounter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 public class CqlCounter extends PrimitiveType {

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlDecimal.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlDecimal.java
@@ -1,0 +1,12 @@
+package org.scassandra.cql;
+
+public class CqlDecimal extends PrimitiveType {
+    CqlDecimal() {
+        super("decimal");
+    }
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        return equalsDecimalType(expected, actual, this);
+
+    }
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlDecimal.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlDecimal.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 public class CqlDecimal extends PrimitiveType {

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlDouble.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlDouble.java
@@ -1,0 +1,12 @@
+package org.scassandra.cql;
+
+public class CqlDouble extends PrimitiveType {
+    CqlDouble() {
+        super("double");
+    }
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        return equalsDecimalType(expected, actual, this);
+
+    }
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlDouble.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlDouble.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 public class CqlDouble extends PrimitiveType {

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlFloat.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlFloat.java
@@ -1,0 +1,13 @@
+package org.scassandra.cql;
+
+public class CqlFloat extends PrimitiveType {
+    CqlFloat() {
+        super("float");
+    }
+
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        return equalsDecimalType(expected, actual, this);
+
+    }
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlFloat.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlFloat.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 public class CqlFloat extends PrimitiveType {

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlInet.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlInet.java
@@ -1,0 +1,28 @@
+package org.scassandra.cql;
+
+import java.net.InetAddress;
+
+public class CqlInet extends PrimitiveType {
+    CqlInet() {
+        super("inet");
+    }
+
+    // comes from the server as a string
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        if (expected == null) return actual == null;
+        if (actual == null) return expected == null;
+
+        if (expected instanceof String) {
+            try {
+                return expected.equals(actual);
+            } catch (Exception e) {
+                throw throwInvalidType(expected, actual, this);
+            }
+        } else if (expected instanceof InetAddress) {
+            return ((InetAddress) expected).getHostAddress().equals(actual);
+        }
+
+        throw throwInvalidType(expected, actual, this);
+    }
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlInet.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlInet.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 import java.net.InetAddress;

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlInt.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlInt.java
@@ -1,0 +1,12 @@
+package org.scassandra.cql;
+
+public class CqlInt extends PrimitiveType {
+    CqlInt() {
+        super("int");
+    }
+
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        return equalsForLongType(expected, actual, this);
+    }
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlInt.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlInt.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 public class CqlInt extends PrimitiveType {

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlText.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlText.java
@@ -1,0 +1,12 @@
+package org.scassandra.cql;
+
+public class CqlText extends PrimitiveType {
+    CqlText() {
+        super("text");
+    }
+
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        return ASCII.equals(expected, actual);
+    }
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlText.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlText.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 public class CqlText extends PrimitiveType {

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlTimestamp.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlTimestamp.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 import java.util.Date;

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlTimestamp.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlTimestamp.java
@@ -1,0 +1,26 @@
+package org.scassandra.cql;
+
+import java.util.Date;
+
+public class CqlTimestamp extends PrimitiveType {
+    CqlTimestamp() {
+        super("timestamp");
+    }
+
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        Long typedActualValue = getActualValueLong(actual);
+
+        if (expected == null) return actual == null;
+        if (actual == null) return expected == null;
+
+        if (expected instanceof Long) {
+            return expected.equals(typedActualValue);
+        } else if (expected instanceof Date) {
+            return ((Date) expected).getTime() == typedActualValue;
+        }
+
+        throw throwInvalidType(expected, actual, this);
+
+    }
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlTimeuuid.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlTimeuuid.java
@@ -1,0 +1,14 @@
+package org.scassandra.cql;
+
+public class CqlTimeuuid extends PrimitiveType {
+    CqlTimeuuid() {
+        super("timeuuid");
+    }
+
+    // comes back from the server as a string
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        return equalsForUUID(expected, actual, this);
+    }
+
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlTimeuuid.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlTimeuuid.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 public class CqlTimeuuid extends PrimitiveType {

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlType.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlType.java
@@ -1,0 +1,17 @@
+package org.scassandra.cql;
+
+abstract public class CqlType {
+    public abstract String serialise();
+    public abstract boolean equals(Object expected, Object actual);
+
+    protected IllegalArgumentException throwInvalidType(Object expected, Object actual, CqlType instance) {
+        return new IllegalArgumentException(String.format("Invalid expected value (%s,%s) for variable of types %s, the value was %s for valid types see: %s",
+                expected,
+                expected.getClass().getSimpleName(),
+                instance.serialise(),
+                actual,
+                "http://www.scassandra.org/java-client/column-types/"
+        ));
+    }
+
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlType.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 abstract public class CqlType {

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlTypeFactory.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlTypeFactory.java
@@ -1,0 +1,104 @@
+package org.scassandra.cql;
+
+import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.misc.NotNull;
+import org.scassandra.antlr4.CqlTypesBaseListener;
+import org.scassandra.antlr4.CqlTypesLexer;
+import org.scassandra.antlr4.CqlTypesParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Stack;
+
+public class CqlTypeFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CqlTypeFactory.class);
+
+    public CqlType buildType(String typeString) {
+        CqlTypesLexer lexer = new CqlTypesLexer(new ANTLRInputStream(typeString));
+        CqlTypesParser parser = new CqlTypesParser(new CommonTokenStream(lexer));
+
+        parser.addErrorListener(new BaseErrorListener() {
+            @Override
+            public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
+                throw new IllegalArgumentException(msg);
+            }
+        });
+
+        CqlTypesBaseListenerImpl listener = new CqlTypesBaseListenerImpl();
+        parser.addParseListener(listener);
+
+        parser.data_type();
+        return listener.getCqlType();
+    }
+
+    private static class CqlTypesBaseListenerImpl extends CqlTypesBaseListener {
+
+        private CqlType cqlType;
+        private Stack<CqlType> inProgress = new Stack<CqlType>();
+
+        @Override
+        public void enterData_type(@NotNull CqlTypesParser.Data_typeContext ctx) {
+            LOGGER.debug("Type begins: " + ctx.start.getText());
+        }
+
+        @Override
+        public void exitData_type(@NotNull CqlTypesParser.Data_typeContext ctx) {
+            LOGGER.debug("Type ends: " + ctx.start.getText());
+        }
+
+        @Override
+        public void exitNative_type(@NotNull CqlTypesParser.Native_typeContext ctx) {
+            String text = ctx.start.getText();
+            PrimitiveType primitiveType = PrimitiveType.fromName(text);
+            if (inProgress.isEmpty()) {
+                this.cqlType = primitiveType;
+            } else {
+                inProgress.push(primitiveType);
+            }
+        }
+
+        @Override
+        public void enterMap_type(@NotNull CqlTypesParser.Map_typeContext ctx) {
+            LOGGER.debug("end map:" + ctx.start.getText());
+            this.inProgress.push(new MapType(null, null));
+        }
+
+        @Override
+        public void exitMap_type(@NotNull CqlTypesParser.Map_typeContext ctx) {
+            LOGGER.debug("start map:" + ctx.start.getText());
+            CqlType value = inProgress.pop();
+            CqlType key = inProgress.pop();
+            inProgress.pop();
+            this.cqlType = new MapType(key, value);
+        }
+
+        @Override
+        public void enterSet_type(@NotNull CqlTypesParser.Set_typeContext ctx) {
+            this.inProgress.push(new SetType(null));
+        }
+
+        @Override
+        public void exitSet_type(@NotNull CqlTypesParser.Set_typeContext ctx) {
+            CqlType value = inProgress.pop();
+            inProgress.pop();
+            this.cqlType = new SetType(value);
+        }
+
+        @Override
+        public void enterList_type(@NotNull CqlTypesParser.List_typeContext ctx) {
+            this.inProgress.push(new ListType(null));
+        }
+
+        @Override
+        public void exitList_type(@NotNull CqlTypesParser.List_typeContext ctx) {
+            CqlType value = inProgress.pop();
+            inProgress.pop();
+            this.cqlType = new ListType(value);
+        }
+
+        public CqlType getCqlType() {
+            return cqlType;
+        }
+    }
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlTypeFactory.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlTypeFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 import org.antlr.v4.runtime.*;

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlUuid.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlUuid.java
@@ -1,0 +1,13 @@
+package org.scassandra.cql;
+
+public class CqlUuid extends PrimitiveType {
+    CqlUuid() {
+        super("uuid");
+    }
+
+    // comes back from the server as a string
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        return equalsForUUID(expected, actual, this);
+    }
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlUuid.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlUuid.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 public class CqlUuid extends PrimitiveType {

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlVarchar.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlVarchar.java
@@ -1,0 +1,12 @@
+package org.scassandra.cql;
+
+public class CqlVarchar extends PrimitiveType {
+    CqlVarchar() {
+        super("varchar");
+    }
+
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        return ASCII.equals(expected, actual);
+    }
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlVarchar.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlVarchar.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 public class CqlVarchar extends PrimitiveType {

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlVarint.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlVarint.java
@@ -1,0 +1,28 @@
+package org.scassandra.cql;
+
+import java.math.BigInteger;
+
+public class CqlVarint extends PrimitiveType {
+    CqlVarint() {
+        super("varint");
+    }
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        if (expected == null) return actual == null;
+        if (actual == null) return expected == null;
+
+        Long typedActual = getActualValueLong(actual);
+
+        if (expected instanceof BigInteger) {
+            return expected.equals(new BigInteger(typedActual.toString()));
+        } else if (expected instanceof String) {
+            try {
+                return new BigInteger((String) expected).equals(new BigInteger(typedActual.toString()));
+            } catch (NumberFormatException e) {
+                throw throwInvalidType(expected, actual, this);
+            }
+        } else {
+            throw throwInvalidType(expected, actual, this);
+        }
+    }
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/CqlVarint.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/CqlVarint.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 import java.math.BigInteger;

--- a/cql-antlr/src/main/java/org/scassandra/cql/ListType.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/ListType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 import java.util.List;

--- a/cql-antlr/src/main/java/org/scassandra/cql/ListType.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/ListType.java
@@ -1,0 +1,66 @@
+package org.scassandra.cql;
+
+import java.util.List;
+
+public class ListType extends CqlType {
+    private final CqlType type;
+
+    public static ListType list(CqlType type) {
+        return new ListType(type);
+    }
+
+    ListType(CqlType type) {
+        this.type = type;
+    }
+
+    @Override
+    public String serialise() {
+        return String.format("list<%s>", type.serialise());
+    }
+
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        if (expected == null) return actual == null;
+        if (actual == null) return false;
+
+        if (expected instanceof List) {
+            final List<?> typedExpected = (List<?>) expected;
+            final List<?> actualList = (List<?>) actual;
+
+            if (typedExpected.size() != actualList.size()) return false;
+
+            for (int i = 0; i < actualList.size(); i++) {
+                if (!type.equals(typedExpected.get(i), actualList.get(i))) return false;
+            }
+            return true;
+        } else {
+            throw throwInvalidType(expected, actual, this);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ListType setType = (ListType) o;
+
+        if (type != null ? !type.equals(setType.type) : setType.type != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return type != null ? type.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return this.serialise();
+    }
+
+    public CqlType getType() {
+        return type;
+    }
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/MapType.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/MapType.java
@@ -1,0 +1,86 @@
+package org.scassandra.cql;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+
+import java.util.Map;
+
+public class MapType extends CqlType {
+    private CqlType keyType;
+    private CqlType valueType;
+
+    public static MapType map(CqlType keyType, CqlType valueType) {
+        return new MapType(keyType, valueType);
+    }
+
+    MapType(CqlType keyType, CqlType valueType) {
+        this.keyType = keyType;
+        this.valueType = valueType;
+    }
+
+    @Override
+    public String serialise() {
+        return String.format("map<%s,%s>", keyType.serialise(), valueType.serialise());
+    }
+
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        if (expected == null) return actual == null;
+        if (actual == null) return false;
+
+        if (expected instanceof Map) {
+            final Map<?,?> typedExpected = (Map<?, ?>) expected;
+            final Map<?,?> actualMap = (Map<?, ?>) actual;
+
+            if (typedExpected.size() != actualMap.size()) return false;
+
+            for (final Map.Entry<?, ?> eachExpected : typedExpected.entrySet()) {
+                boolean match = Iterables.any(actualMap.keySet(), new Predicate<Object>() {
+                    @Override
+                    public boolean apply(Object eachActualKey) {
+                        Object eachActual = actualMap.get(eachActualKey);
+                        return keyType.equals(eachExpected.getKey(), eachActualKey) && valueType.equals(eachExpected.getValue(), eachActual);
+                    }
+                });
+
+                if (!match) return false;
+            }
+            return true;
+        } else {
+            throw throwInvalidType(expected, actual, this);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return this.serialise();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        MapType mapType1 = (MapType) o;
+
+        if (keyType != null ? !keyType.equals(mapType1.keyType) : mapType1.keyType != null) return false;
+        if (valueType != null ? !valueType.equals(mapType1.valueType) : mapType1.valueType != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = keyType != null ? keyType.hashCode() : 0;
+        result = 31 * result + (valueType != null ? valueType.hashCode() : 0);
+        return result;
+    }
+
+    public CqlType getKeyType() {
+        return keyType;
+    }
+
+    public CqlType getValueType() {
+        return valueType;
+    }
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/MapType.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/MapType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 import com.google.common.base.Predicate;

--- a/cql-antlr/src/main/java/org/scassandra/cql/PrimitiveType.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/PrimitiveType.java
@@ -1,0 +1,139 @@
+package org.scassandra.cql;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
+
+abstract public class PrimitiveType extends CqlType {
+
+    private static final Map<String, PrimitiveType> mapping = new HashMap<String, PrimitiveType>();
+
+    public static final PrimitiveType VARCHAR = registerPrimitive(new CqlVarchar());
+    public static final PrimitiveType TEXT = registerPrimitive(new CqlText());
+    public static final PrimitiveType ASCII = registerPrimitive(new CqlAscii());
+    public static final PrimitiveType DOUBLE = registerPrimitive(new CqlDouble());
+    public static final PrimitiveType FLOAT = registerPrimitive(new CqlFloat());
+    public static final PrimitiveType INET = registerPrimitive(new CqlInet());
+    public static final PrimitiveType INT = registerPrimitive(new CqlInt());
+    public static final PrimitiveType BIG_INT = registerPrimitive(new CqlBigInt());
+    public static final PrimitiveType TIMESTAMP = registerPrimitive(new CqlTimestamp());
+    public static final PrimitiveType TIMEUUID = registerPrimitive(new CqlTimeuuid());
+    public static final PrimitiveType UUID = registerPrimitive(new CqlUuid());
+    public static final PrimitiveType VAR_INT = registerPrimitive(new CqlVarint());
+    public static final PrimitiveType BLOB = registerPrimitive(new CqlBlob());
+    public static final PrimitiveType BOOLEAN = registerPrimitive(new CqlBoolean());
+    public static final PrimitiveType COUNTER = registerPrimitive(new CqlCounter());
+    public static final PrimitiveType DECIMAL = registerPrimitive(new CqlDecimal());
+
+    private final String columnType;
+
+    private static PrimitiveType registerPrimitive(PrimitiveType primitiveType) {
+        mapping.put(primitiveType.serialise(), primitiveType);
+        return primitiveType;
+    }
+
+    public static PrimitiveType fromName(String name) {
+        return mapping.get(name);
+    }
+
+    PrimitiveType(String columnType) {
+        this.columnType = columnType;
+    }
+
+    @Override
+    public String serialise() {
+        return columnType;
+    }
+
+    @Override
+    public String toString() {
+        return serialise();
+    }
+
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        return false;
+    }
+
+    protected boolean equalsForLongType(Object expected, Object actual, CqlType columnTypes) {
+
+        if (expected == null) return actual == null;
+        if (actual == null) return false;
+
+        Long typedActual = getActualValueLong(actual);
+
+        if (expected instanceof Integer) {
+            return ((Integer) expected).longValue() == typedActual;
+        } else if (expected instanceof Long) {
+            return expected.equals(typedActual);
+        } else if (expected instanceof BigInteger) {
+            return expected.equals(new BigInteger(typedActual.toString()));
+        } else if (expected instanceof String) {
+            return compareStringInteger(expected, typedActual, columnTypes);
+        } else {
+            throw throwInvalidType(expected, actual, columnTypes);
+        }
+    }
+
+    protected long getActualValueLong(Object actual) {
+        if (actual instanceof Double) {
+            return ((Double) actual).longValue();
+        } else {
+            return Long.parseLong(actual.toString());
+        }
+    }
+
+    protected boolean compareStringInteger(Object expected, Long actual, CqlType instance) {
+        try {
+            return new BigInteger((String) expected).equals(new BigInteger(actual.toString()));
+        } catch (NumberFormatException e) {
+            throw throwInvalidType(expected, actual, instance);
+        }
+    }
+    protected IllegalArgumentException throwNullError(Object actual, CqlType instance) {
+        return new IllegalArgumentException(String.format("Invalid expected value (null) for variable of types %s, the value was %s for valid types see: %s",
+                instance.serialise(),
+                actual,
+                "http://www.scassandra.org/java-client/column-types/"
+        ));
+    }
+
+    protected boolean equalsDecimalType(Object expected, Object actual, CqlType columnTypes) {
+        if (expected == null) {
+            throw throwNullError(actual, columnTypes);
+        } else if (actual == null) {
+            return false;
+        }
+
+        if (expected instanceof String) {
+            try {
+                return (new BigDecimal(expected.toString()).compareTo(new BigDecimal(actual.toString())) == 0);
+            } catch (NumberFormatException e) {
+                throw throwInvalidType(expected, actual, columnTypes);
+            }
+        } else if (expected instanceof BigDecimal) {
+            return ((BigDecimal) expected).compareTo(new BigDecimal(actual.toString())) == 0;
+        } else {
+            throw throwInvalidType(expected, actual, columnTypes);
+        }
+    }
+
+    protected boolean equalsForUUID(Object expected, Object actual, CqlType columnTypes) {
+        if (expected == null) return actual == null;
+        if (actual == null) return false;
+
+        if (expected instanceof String) {
+            try {
+                return java.util.UUID.fromString(expected.toString()).equals(java.util.UUID.fromString(actual.toString()));
+            } catch (Exception e) {
+                throw throwInvalidType(expected, actual, columnTypes);
+            }
+        } else if (expected instanceof java.util.UUID) {
+            return expected.toString().equals(actual);
+        } else {
+            throw throwInvalidType(expected, actual, columnTypes);
+        }
+    }
+
+}

--- a/cql-antlr/src/main/java/org/scassandra/cql/PrimitiveType.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/PrimitiveType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 import java.math.BigDecimal;

--- a/cql-antlr/src/main/java/org/scassandra/cql/SetType.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/SetType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 import com.google.common.base.Predicate;

--- a/cql-antlr/src/main/java/org/scassandra/cql/SetType.java
+++ b/cql-antlr/src/main/java/org/scassandra/cql/SetType.java
@@ -1,0 +1,78 @@
+package org.scassandra.cql;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+
+import java.util.List;
+import java.util.Set;
+
+public class SetType extends CqlType {
+
+    public static SetType set(CqlType type) {
+        return new SetType(type);
+    }
+
+    private final CqlType type;
+
+    SetType(CqlType type) {
+        this.type = type;
+    }
+
+    @Override
+    public String serialise() {
+        return String.format("set<%s>", type.serialise());
+    }
+
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        if (expected == null) return actual == null;
+        if (actual == null) return false;
+
+        if (expected instanceof Set) {
+            final Set<?> typedExpected = (Set<?>) expected;
+            final List<?> actualList = (List<?>) actual;
+
+            return typedExpected.size() == actualList.size() &&
+                    Iterables.all(typedExpected, new Predicate<Object>() {
+                        @Override
+                        public boolean apply(final Object eachExpected) {
+                            return Iterables.any(actualList, new Predicate<Object>() {
+                                @Override
+                                public boolean apply(Object eachActual) {
+                                    return type.equals(eachExpected, eachActual);
+                                }
+                            });
+                        }
+                    });
+
+        } else {
+            throw throwInvalidType(expected, actual, this);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SetType setType = (SetType) o;
+
+        if (type != null ? !type.equals(setType.type) : setType.type != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return type != null ? type.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return this.serialise();
+    }
+
+    public CqlType getType() {
+        return type;
+    }
+}

--- a/cql-antlr/src/test/java/org/scassandra/cql/CqlTypeFactoryTest.java
+++ b/cql-antlr/src/test/java/org/scassandra/cql/CqlTypeFactoryTest.java
@@ -1,0 +1,59 @@
+package org.scassandra.cql;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class CqlTypeFactoryTest {
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"map<ascii,ascii>", new MapType(PrimitiveType.ASCII, PrimitiveType.ASCII) },
+                {"map<blob,inet>", new MapType(PrimitiveType.BLOB, PrimitiveType.INET) },
+                {"map<uuid,timeuuid>", new MapType(PrimitiveType.UUID, PrimitiveType.TIMEUUID) },
+                {"set<ascii>", new SetType(PrimitiveType.ASCII) },
+                {"set<inet>", new SetType(PrimitiveType.INET) },
+                {"list<ascii>", new ListType(PrimitiveType.ASCII) },
+                {"list<boolean>", new ListType(PrimitiveType.BOOLEAN) },
+                {"list<decimal>", new ListType(PrimitiveType.DECIMAL) },
+                {"ascii", PrimitiveType.ASCII},
+                {"varchar", PrimitiveType.VARCHAR},
+                {"bigint", PrimitiveType.BIG_INT},
+                {"blob", PrimitiveType.BLOB},
+                {"boolean", PrimitiveType.BOOLEAN},
+                {"counter", PrimitiveType.COUNTER},
+                {"decimal", PrimitiveType.DECIMAL},
+                {"double", PrimitiveType.DOUBLE},
+                {"float", PrimitiveType.FLOAT},
+                {"int", PrimitiveType.INT},
+                {"timestamp", PrimitiveType.TIMESTAMP},
+                {"varint", PrimitiveType.VAR_INT},
+                {"timeuuid", PrimitiveType.TIMEUUID},
+                {"inet", PrimitiveType.INET},
+                {"text", PrimitiveType.TEXT}
+        });
+    }
+
+    private String input;
+
+    private CqlType expectedType;
+
+    public CqlTypeFactoryTest(String input, CqlType expectedType) {
+        this.input = input;
+        this.expectedType = expectedType;
+    }
+
+    private CqlTypeFactory underTest = new CqlTypeFactory();
+
+    @Test
+    public void test() throws Exception {
+        assertEquals(expectedType, underTest.buildType(input));
+    }
+}

--- a/cql-antlr/src/test/java/org/scassandra/cql/CqlTypeFactoryTest.java
+++ b/cql-antlr/src/test/java/org/scassandra/cql/CqlTypeFactoryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 import org.junit.Test;

--- a/cql-antlr/src/test/java/org/scassandra/cql/CqlTypesEqualsTest.java
+++ b/cql-antlr/src/test/java/org/scassandra/cql/CqlTypesEqualsTest.java
@@ -1,0 +1,317 @@
+package org.scassandra.cql;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.apache.commons.codec.binary.Hex;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+
+import static org.junit.Assert.*;
+import static org.scassandra.cql.CqlTypesEqualsTest.Result.*;
+import static org.scassandra.cql.ListType.list;
+import static org.scassandra.cql.MapType.map;
+import static org.scassandra.cql.PrimitiveType.*;
+import static org.scassandra.cql.SetType.set;
+
+@RunWith(Parameterized.class)
+public class CqlTypesEqualsTest {
+
+    enum Result {
+        MATCH,
+        NO_MATCH,
+        ILLEGAL_ARGUMENT
+    }
+
+    @Parameterized.Parameters(name = "Type: {0} expected: {1}, actual {2}, should be equal: {3}")
+    public static Collection<Object[]> data() throws UnknownHostException {
+        return Arrays.asList(new Object[][]{
+                {ASCII, "one", "one", MATCH},
+                {ASCII, "one", "two", NO_MATCH},
+                {ASCII, "one", null, NO_MATCH},
+                {ASCII, null, "two", NO_MATCH},
+                {ASCII, "one", 5, NO_MATCH},
+                {ASCII, "one", java.util.UUID.randomUUID(), NO_MATCH},
+
+                {TEXT, "one", "one", MATCH},
+                {TEXT, "one", "two", NO_MATCH},
+                {TEXT, "one", null, NO_MATCH},
+                {TEXT, null, "two", NO_MATCH},
+
+                {VARCHAR, "one", "one", MATCH},
+                {VARCHAR, "one", "two", NO_MATCH},
+                {VARCHAR, "one", null, NO_MATCH},
+                {VARCHAR, null, "two", NO_MATCH},
+
+                {BIG_INT, 1, "1", MATCH},
+                {BIG_INT, 1, 1d, MATCH},
+                {BIG_INT, 1l, 1d, MATCH},
+                {BIG_INT, new Long("1"), new Long("1"), MATCH},
+                {BIG_INT, new BigInteger("1"), 1d, MATCH},
+
+                {BIG_INT, null, 1d, NO_MATCH},
+                {BIG_INT, "hello", 1d, ILLEGAL_ARGUMENT},
+
+                {COUNTER, 1, "1", MATCH},
+                {COUNTER, 1, 1d, MATCH},
+                {COUNTER, 1l, 1d, MATCH},
+                {COUNTER, new BigInteger("1"), 1d, MATCH},
+
+                {COUNTER, new BigInteger("1"), null, NO_MATCH},
+                {COUNTER, null, new BigInteger("1"), NO_MATCH},
+                {COUNTER, "hello", 1d, ILLEGAL_ARGUMENT},
+
+                {INT, 1, "1", MATCH},
+                {INT, 1, 1d, MATCH},
+                {INT, "1", 1d, MATCH},
+                {INT, new BigInteger("1"), 1d, MATCH},
+
+                {INT, null, 1, NO_MATCH},
+                {INT, "hello", 1d, ILLEGAL_ARGUMENT},
+
+                {VAR_INT, "1", "1", MATCH},
+                {VAR_INT, "1", 1d, MATCH},
+                {VAR_INT, new BigInteger("1"), 1d, MATCH},
+
+                {VAR_INT, "1", null, NO_MATCH},
+                {VAR_INT, null, 1d, NO_MATCH},
+                {VAR_INT, 1, 1d, ILLEGAL_ARGUMENT},
+                {VAR_INT, 1, 1d, ILLEGAL_ARGUMENT},
+                {VAR_INT, 1l, 1d, ILLEGAL_ARGUMENT},
+                {VAR_INT, "hello", 1d, ILLEGAL_ARGUMENT},
+
+                {BOOLEAN, true, "true", MATCH},
+                {BOOLEAN, true, true, MATCH},
+                {BOOLEAN, false, false, MATCH},
+
+                {BOOLEAN, true, false, NO_MATCH},
+                {BOOLEAN, null, false, ILLEGAL_ARGUMENT},
+                {BOOLEAN, true, false, NO_MATCH},
+                {BOOLEAN, 1, false, ILLEGAL_ARGUMENT},
+                {BOOLEAN, "true", false, ILLEGAL_ARGUMENT},
+                {BOOLEAN, new BigDecimal("1.2"), false, ILLEGAL_ARGUMENT},
+
+                {BLOB, "0x0012345435345345435435", "0x0012345435345345435435", MATCH},
+                {BLOB, ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), "0x" + Hex.encodeHexString(new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), MATCH},
+
+                {BLOB, ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), "0x" + Hex.encodeHexString(new byte[]{1, 2, 3, 4, 5, 6, 7, 8}), NO_MATCH},
+                {BLOB, "0x0012345435345345435435", "0x0012345435345345435433", NO_MATCH},
+                {BLOB, 1, "0x0012345435345345435435", ILLEGAL_ARGUMENT},
+                {BLOB, new BigInteger("1"), "0x0012345435345345435435", ILLEGAL_ARGUMENT},
+                {BLOB, new BigDecimal("1"), "0x0012345435345345435435", ILLEGAL_ARGUMENT},
+                {BLOB, null, "0x0012345435345345435433", ILLEGAL_ARGUMENT},
+
+                {DECIMAL, "1", "1", MATCH},
+                {DECIMAL, "1.0000", "1", MATCH},
+                {DECIMAL, new BigDecimal("1.0000"), "1", MATCH},
+
+                {DECIMAL, "1", null, NO_MATCH},
+                {DECIMAL, "1", "2", NO_MATCH},
+                {DECIMAL, new BigInteger("1"), "1.234", ILLEGAL_ARGUMENT},
+                {DECIMAL, null, "1", ILLEGAL_ARGUMENT},
+                {DECIMAL, 1, "1", ILLEGAL_ARGUMENT},
+                {DECIMAL, 1, 1, ILLEGAL_ARGUMENT},
+                {DECIMAL, 1l, 1, ILLEGAL_ARGUMENT},
+                {DECIMAL, "hello", new BigInteger("1"), ILLEGAL_ARGUMENT},
+                {DECIMAL, "hello", 1, ILLEGAL_ARGUMENT},
+
+                {FLOAT, "1", "1", MATCH},
+                {FLOAT, "1.0000", "1", MATCH},
+
+                {FLOAT, "1", null, NO_MATCH},
+                {FLOAT, "1", "2", NO_MATCH},
+                {FLOAT, new BigInteger("1"), "1.234", ILLEGAL_ARGUMENT},
+                {FLOAT, null, "1", ILLEGAL_ARGUMENT},
+                {FLOAT, 1, "1", ILLEGAL_ARGUMENT},
+                {FLOAT, 1, 1, ILLEGAL_ARGUMENT},
+                {FLOAT, 1l, 1, ILLEGAL_ARGUMENT},
+                {FLOAT, "hello", new BigInteger("1"), ILLEGAL_ARGUMENT},
+                {FLOAT, "hello", 1, ILLEGAL_ARGUMENT},
+
+                {DOUBLE, "1", "1", MATCH},
+                {DOUBLE, "1.0000", "1", MATCH},
+
+                {DOUBLE, "1", null, NO_MATCH},
+                {DOUBLE, "1", "2", NO_MATCH},
+                {DOUBLE, new BigInteger("1"), "1.234", ILLEGAL_ARGUMENT},
+                {DOUBLE, null, "1", ILLEGAL_ARGUMENT},
+                {DOUBLE, 1, "1", ILLEGAL_ARGUMENT},
+                {DOUBLE, 1, 1, ILLEGAL_ARGUMENT},
+                {DOUBLE, 1l, 1, ILLEGAL_ARGUMENT},
+                {DOUBLE, "hello", new BigInteger("1"), ILLEGAL_ARGUMENT},
+                {DOUBLE, "hello", 1, ILLEGAL_ARGUMENT},
+
+                {TIMESTAMP, 1l, "1", MATCH},
+                {TIMESTAMP, 1l, 1d, MATCH},
+                {TIMESTAMP, new Date(1l), 1d, MATCH},
+                {TIMESTAMP, null, 1d, NO_MATCH},
+
+                {TIMESTAMP, 1l, 12d, NO_MATCH},
+                {TIMESTAMP, 1, 1d, ILLEGAL_ARGUMENT},
+                {TIMESTAMP, "1", 1d, ILLEGAL_ARGUMENT},
+                {TIMESTAMP, new BigInteger("1"), 1d, ILLEGAL_ARGUMENT},
+                {TIMESTAMP, "hello", 1d, ILLEGAL_ARGUMENT},
+
+                {TIMEUUID, "59ad61d0-c540-11e2-881e-b9e6057626c4", "59ad61d0-c540-11e2-881e-b9e6057626c4", MATCH},
+                {TIMEUUID, java.util.UUID.fromString("59ad61d0-c540-11e2-881e-b9e6057626c4"), "59ad61d0-c540-11e2-881e-b9e6057626c4", MATCH},
+
+                {TIMEUUID, java.util.UUID.randomUUID(), "59ad61d0-c540-11e2-881e-b9e6057626c4", NO_MATCH},
+                {TIMEUUID, java.util.UUID.randomUUID().toString(), "59ad61d0-c540-11e2-881e-b9e6057626c4", NO_MATCH},
+                {TIMEUUID, null, "59ad61d0-c540-11e2-881e-b9e6057626c4", NO_MATCH},
+                {TIMEUUID, "59ad61d0-c540-11e2-881e-b9e6057626c4", null, NO_MATCH},
+
+                {TIMEUUID, new Date(1l), "59ad61d0-c540-11e2-881e-b9e6057626c4", ILLEGAL_ARGUMENT},
+                {TIMEUUID, 1l, "59ad61d0-c540-11e2-881e-b9e6057626c4", ILLEGAL_ARGUMENT},
+                {TIMEUUID, 1, "59ad61d0-c540-11e2-881e-b9e6057626c4", ILLEGAL_ARGUMENT},
+                {TIMEUUID, "1", "59ad61d0-c540-11e2-881e-b9e6057626c4", ILLEGAL_ARGUMENT},
+                {TIMEUUID, new BigInteger("1"), "59ad61d0-c540-11e2-881e-b9e6057626c4", ILLEGAL_ARGUMENT},
+                {TIMEUUID, "hello", "59ad61d0-c540-11e2-881e-b9e6057626c4", ILLEGAL_ARGUMENT},
+
+                {UUID, "59ad61d0-c540-11e2-881e-b9e6057626c4", "59ad61d0-c540-11e2-881e-b9e6057626c4", MATCH},
+                {UUID, java.util.UUID.fromString("59ad61d0-c540-11e2-881e-b9e6057626c4"), "59ad61d0-c540-11e2-881e-b9e6057626c4", MATCH},
+
+                {UUID, java.util.UUID.randomUUID(), "59ad61d0-c540-11e2-881e-b9e6057626c4", NO_MATCH},
+                {UUID, java.util.UUID.randomUUID().toString(), "59ad61d0-c540-11e2-881e-b9e6057626c4", NO_MATCH},
+                {UUID, null, "59ad61d0-c540-11e2-881e-b9e6057626c4", NO_MATCH},
+                {UUID, "59ad61d0-c540-11e2-881e-b9e6057626c4", null, NO_MATCH},
+
+                {UUID, new Date(1l), "59ad61d0-c540-11e2-881e-b9e6057626c4", ILLEGAL_ARGUMENT},
+                {UUID, 1l, "59ad61d0-c540-11e2-881e-b9e6057626c4", ILLEGAL_ARGUMENT},
+                {UUID, 1, "59ad61d0-c540-11e2-881e-b9e6057626c4", ILLEGAL_ARGUMENT},
+                {UUID, "1", "59ad61d0-c540-11e2-881e-b9e6057626c4", ILLEGAL_ARGUMENT},
+                {UUID, new BigInteger("1"), "59ad61d0-c540-11e2-881e-b9e6057626c4", ILLEGAL_ARGUMENT},
+                {UUID, "hello", "59ad61d0-c540-11e2-881e-b9e6057626c4", ILLEGAL_ARGUMENT},
+
+                {INET, InetAddress.getLocalHost(), InetAddress.getLocalHost().getHostAddress(), MATCH},
+                {INET, InetAddress.getLocalHost().getHostAddress(), InetAddress.getLocalHost().getHostAddress(), MATCH},
+
+                {INET, InetAddress.getLocalHost(), "192.168.56.56", NO_MATCH},
+                {INET, InetAddress.getLocalHost().getHostAddress(), "192.168.56.56", NO_MATCH},
+
+                {INET, null, InetAddress.getLocalHost().getHostAddress(), NO_MATCH},
+                {INET, InetAddress.getLocalHost().getHostAddress(), null, NO_MATCH},
+
+                {INET, new Date(1l), InetAddress.getLocalHost().getHostAddress(), ILLEGAL_ARGUMENT},
+                {INET, 1l, InetAddress.getLocalHost().getHostAddress(), ILLEGAL_ARGUMENT},
+                {INET, 1, InetAddress.getLocalHost().getHostAddress(), ILLEGAL_ARGUMENT},
+                {INET, new BigInteger("1"), InetAddress.getLocalHost().getHostAddress(), ILLEGAL_ARGUMENT},
+
+                {new SetType(TEXT), Sets.newHashSet("one"), Lists.newArrayList("one"), MATCH},
+                {new SetType(TEXT), Sets.newHashSet("one"), Lists.newArrayList("two"), NO_MATCH},
+                {new SetType(TEXT), Sets.newHashSet("one"), Lists.newArrayList("one", "two"), NO_MATCH},
+                {new SetType(TEXT), null, Lists.newArrayList("one", "two"), NO_MATCH},
+                {new SetType(TEXT), Sets.newHashSet("one"), null, NO_MATCH},
+
+                {new SetType(TEXT), new Date(1l), Lists.newArrayList("one"), ILLEGAL_ARGUMENT},
+                {new SetType(TEXT), 1l, Lists.newArrayList("one"), ILLEGAL_ARGUMENT},
+                {new SetType(TEXT), 1, Lists.newArrayList("one"), ILLEGAL_ARGUMENT},
+                {new SetType(TEXT), new BigInteger("1"), Lists.newArrayList("one"), ILLEGAL_ARGUMENT},
+
+                {new SetType(ASCII), Sets.newHashSet("one"), Lists.newArrayList("one"), MATCH},
+                {new SetType(ASCII), Sets.newHashSet("one"), Lists.newArrayList("one", "two"), NO_MATCH},
+                {new SetType(ASCII), null, Lists.newArrayList("one", "two"), NO_MATCH},
+                {new SetType(ASCII), Sets.newHashSet("one"), null, NO_MATCH},
+
+                {new SetType(ASCII), new Date(1l), Lists.newArrayList("one"), ILLEGAL_ARGUMENT},
+                {new SetType(ASCII), 1l, Lists.newArrayList("one"), ILLEGAL_ARGUMENT},
+                {new SetType(ASCII), 1, Lists.newArrayList("one"), ILLEGAL_ARGUMENT},
+                {new SetType(ASCII), new BigInteger("1"), Lists.newArrayList("one"), ILLEGAL_ARGUMENT},
+
+                {new SetType(VARCHAR), Sets.newHashSet("one"), Lists.newArrayList("one"), MATCH},
+                {set(VARCHAR), Sets.newHashSet("one"), Lists.newArrayList("one", "two"), NO_MATCH},
+                {set(VARCHAR), null, Lists.newArrayList("one", "two"), NO_MATCH},
+                {set(VARCHAR), Sets.newHashSet("one"), null, NO_MATCH},
+
+                {set(VARCHAR), new Date(1l), Lists.newArrayList("one"), ILLEGAL_ARGUMENT},
+                {set(VARCHAR), 1l, Lists.newArrayList("one"), ILLEGAL_ARGUMENT},
+                {set(VARCHAR), 1, Lists.newArrayList("one"), ILLEGAL_ARGUMENT},
+                {set(VARCHAR), new BigInteger("1"), Lists.newArrayList("one"), ILLEGAL_ARGUMENT},
+
+                {set(UUID), Sets.newHashSet(java.util.UUID.randomUUID()), Lists.newArrayList("59ad61d0-c540-11e2-881e-b9e6057626c4"), NO_MATCH},
+                {set(UUID), Sets.newHashSet(java.util.UUID.randomUUID().toString()), Lists.newArrayList("59ad61d0-c540-11e2-881e-b9e6057626c4"), NO_MATCH},
+                {set(UUID), Sets.newHashSet((java.util.UUID) null), Lists.newArrayList("59ad61d0-c540-11e2-881e-b9e6057626c4"), NO_MATCH},
+                {set(UUID), Sets.newHashSet("59ad61d0-c540-11e2-881e-b9e6057626c4"), Lists.newArrayList((java.util.UUID) null), NO_MATCH},
+
+                {set(UUID), new Date(1l), Lists.newArrayList("59ad61d0-c540-11e2-881e-b9e6057626c4"), ILLEGAL_ARGUMENT},
+                {set(UUID), 1l, Lists.newArrayList("59ad61d0-c540-11e2-881e-b9e6057626c4"), ILLEGAL_ARGUMENT},
+                {set(UUID), 1, Lists.newArrayList("59ad61d0-c540-11e2-881e-b9e6057626c4"), ILLEGAL_ARGUMENT},
+                {set(UUID), "1", Lists.newArrayList("59ad61d0-c540-11e2-881e-b9e6057626c4"), ILLEGAL_ARGUMENT},
+                {set(UUID), new BigInteger("1"), Lists.newArrayList("59ad61d0-c540-11e2-881e-b9e6057626c4"), ILLEGAL_ARGUMENT},
+                {set(UUID), "hello", Lists.newArrayList("59ad61d0-c540-11e2-881e-b9e6057626c4"), ILLEGAL_ARGUMENT},
+
+                {list(TEXT), Lists.newArrayList("one"), Lists.newArrayList("one"), MATCH},
+                {list(TEXT), Lists.newArrayList("one"), Lists.newArrayList("two"), NO_MATCH},
+                {list(TEXT), Lists.newArrayList("one", "two"), Lists.newArrayList("one", "two"), MATCH},
+                {list(TEXT), Lists.newArrayList("one", "two"), Lists.newArrayList("two", "one"), NO_MATCH},
+                {list(TEXT), Lists.newArrayList("one"), Lists.newArrayList("one", "two"), NO_MATCH},
+                {list(TEXT), null, Lists.newArrayList("one", "two"), NO_MATCH},
+                {list(TEXT), Lists.newArrayList("one"), null, NO_MATCH},
+
+                {list(TEXT), new Date(1l), Lists.newArrayList("one"), ILLEGAL_ARGUMENT},
+                {list(TEXT), 1l, Lists.newArrayList("one"), ILLEGAL_ARGUMENT},
+                {list(TEXT), 1, Lists.newArrayList("one"), ILLEGAL_ARGUMENT},
+                {list(TEXT), new BigInteger("1"), Lists.newArrayList("one"), ILLEGAL_ARGUMENT},
+
+                {map(TEXT, TEXT), ImmutableMap.of("ONE", "1"), ImmutableMap.of("ONE", "1"), MATCH},
+                {map(TEXT, TEXT), ImmutableMap.of(), ImmutableMap.of(), MATCH},
+                {map(TEXT, TEXT), ImmutableMap.of("ONE", "1", "TWO", "2"), ImmutableMap.of("ONE", "1"), NO_MATCH},
+                {map(TEXT, TEXT), ImmutableMap.of("ONE", "1"), ImmutableMap.of("ONE", "1", "TWO", "2"), NO_MATCH},
+                {map(TEXT, TEXT), ImmutableMap.of("ONE", "1"), ImmutableMap.of("ONE", "2"), NO_MATCH},
+                {map(TEXT, TEXT), ImmutableMap.of("ONE", "1"), ImmutableMap.of("ONE", "2"), NO_MATCH},
+                {map(TEXT, TEXT), ImmutableMap.of("ONE", "1"), ImmutableMap.of("TWO", "1"), NO_MATCH},
+                {map(TEXT, TEXT), null, ImmutableMap.of("TWO", "1"), NO_MATCH},
+                {map(TEXT, TEXT), ImmutableMap.of("ONE", "1"), null, NO_MATCH},
+
+                {map(TEXT, TEXT), new Date(1l), ImmutableMap.of("ONE", "1"), ILLEGAL_ARGUMENT},
+                {map(TEXT, TEXT), 1l, ImmutableMap.of("ONE", "1"), ILLEGAL_ARGUMENT},
+                {map(TEXT, TEXT), 1, ImmutableMap.of("ONE", "1"), ILLEGAL_ARGUMENT},
+                {map(TEXT, TEXT), new BigInteger("1"), ImmutableMap.of("ONE", "1"), ILLEGAL_ARGUMENT},
+        });
+    }
+
+    private CqlType type;
+    private Object expected;
+    private Object actual;
+    private Result match;
+
+    public CqlTypesEqualsTest(CqlType type, Object expected, Object actual, Result match) {
+        this.type = type;
+        this.expected = expected;
+        this.actual = actual;
+        this.match = match;
+    }
+
+    @Test
+    public void test() throws Exception {
+        switch(match) {
+            case MATCH : {
+                assertTrue(type.equals(expected, actual));
+                break;
+            }
+            case NO_MATCH : {
+                boolean equals = type.equals(expected, actual);
+                assertFalse("Expected no match but got: " + equals, equals);
+                break;
+            }
+            case ILLEGAL_ARGUMENT : {
+                try {
+                    boolean equals = type.equals(expected, actual);
+                    fail("Expected Illegal Argument Exception, actual: " + equals);
+                } catch (IllegalArgumentException e) {
+                    assertTrue(e.getMessage().contains(type.serialise()));
+                }
+                break;
+            }
+        }
+    }
+}

--- a/cql-antlr/src/test/java/org/scassandra/cql/CqlTypesEqualsTest.java
+++ b/cql-antlr/src/test/java/org/scassandra/cql/CqlTypesEqualsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Christopher Batey and Dogan Narinc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scassandra.cql;
 
 import com.google.common.collect.ImmutableMap;

--- a/cql-antlr/src/test/resources/logback.xml
+++ b/cql-antlr/src/test/resources/logback.xml
@@ -1,0 +1,12 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date %-5level [%thread] - [%logger]- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/cql-antlr/src/test/resources/logback.xml
+++ b/cql-antlr/src/test/resources/logback.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright (C) 2016 Christopher Batey and Dogan Narinc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <configuration>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">

--- a/java-client/build.gradle
+++ b/java-client/build.gradle
@@ -118,18 +118,18 @@ uploadArchives {
 }
 
 dependencies {
+    compile project(':cql-antlr')
     compile project(':server')
-    compile 'org.scassandra:cql-antlr:0.1.1'
-    compile 'org.apache.httpcomponents:httpclient:4.3.3'
-    compile 'com.google.code.gson:gson:2.5'
-    compile 'org.slf4j:slf4j-api:1.7.6'
-    compile 'junit:junit:4.11'
-    testCompile 'ch.qos.logback:logback-classic:1.1.1'
-    testCompile 'org.mockito:mockito-all:1.9.5'
-    testCompile 'com.github.tomakehurst:wiremock:1.46'
-    testCompile 'nl.jqno.equalsverifier:equalsverifier:1.7.3'
+    compile "org.apache.httpcomponents:httpclient:$httpClientVersion"
+    compile "com.google.code.gson:gson:$gsonVersion"
+    compile "org.slf4j:slf4j-api:$slf4jVersion"
+    compile "junit:junit:$junitVersion"
+    testCompile "ch.qos.logback:logback-classic:$logbackVersion"
+    testCompile "org.mockito:mockito-all:$mockitoVersion"
+    testCompile "com.github.tomakehurst:wiremock:1.46"
+    testCompile "nl.jqno.equalsverifier:equalsverifier:1.7.3"
     testCompile "com.googlecode.jarjar:jarjar:1.3"
-    testCompile('com.datastax.cassandra:cassandra-driver-core:2.0.5')
+    testCompile "com.datastax.cassandra:cassandra-driver-core:$javaDriverVersion"
 }
 
 task wrapper(type: Wrapper) {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -129,25 +129,25 @@ uploadArchives {
 }
 
 dependencies {
-    compile 'org.scala-lang:scala-library:2.11.7'
-    compile  "ch.qos.logback:logback-classic:1.0.13"
-    compile  "com.typesafe.akka:akka-actor_2.11:2.3.9"
-    compile  "com.typesafe.akka:akka-remote_2.11:2.3.9"
-    compile  "com.typesafe.akka:akka-slf4j_2.11:2.3.9"
-    compile  "io.spray:spray-json_2.11:1.3.2"
-    compile  "io.spray:spray-can_2.11:1.3.3"
-    compile  "io.spray:spray-routing-shapeless2_2.11:1.3.3"
+    compile "org.scala-lang:scala-library:$scalaVersion"
+    compile  project(':cql-antlr')
+    compile  "ch.qos.logback:logback-classic:$logbackVersion"
+    compile  "com.typesafe.akka:akka-actor_2.11:$akkaVersion"
+    compile  "com.typesafe.akka:akka-remote_2.11:$akkaVersion"
+    compile  "com.typesafe.akka:akka-slf4j_2.11:$akkaVersion"
+    compile  "io.spray:spray-json_2.11:$sprayJsonVersion"
+    compile  "io.spray:spray-can_2.11:$sprayVersion"
+    compile  "io.spray:spray-routing-shapeless2_2.11:$sprayVersion"
     compile  "com.typesafe.scala-logging:scala-logging_2.11:3.1.0"
-    compile  "com.google.guava:guava:17.0"
-    compile  "org.scassandra:cql-antlr:0.1.1"
+    compile  "com.google.guava:guava:$guavaVersion"
 
-    testCompile "com.typesafe.akka:akka-testkit_2.11:2.3.9"
-    testCompile "io.spray:spray-testkit_2.11:1.3.3"
+    testCompile "com.typesafe.akka:akka-testkit_2.11:$akkaVersion"
+    testCompile "io.spray:spray-testkit_2.11:$sprayVersion"
     testCompile "com.datastax.cassandra:cassandra-driver-core:2.0.10" //exclude("com.google.guava", "guava"),
     testCompile "net.databinder.dispatch:dispatch-core_2.11:0.11.0"
     testCompile "org.scalatest:scalatest_2.11:2.2.3"
-    testCompile "org.mockito:mockito-core:1.9.5"
-    testRuntime 'org.pegdown:pegdown:1.1.0'
+    testCompile "org.mockito:mockito-core:$mockitoVersion"
+    testRuntime "org.pegdown:pegdown:1.1.0"
 }
 
 test {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
+include 'cql-antlr'
 include 'server'
 include 'java-client'
 include 'java-it-tests'


### PR DESCRIPTION
From scassandra/cql-antlr#3 we discussed moving cql-antlr in as a submodule to make it easier to coordinate changes in scassandra that require changes to cql-antlr.

This works good, but currently there is something I need to fix in the gradle-build for cql-antlr.  It builds properly, but the travis build fails because successive runs don't properly skip the antlr4 task that was previously run because i currently have it set up to generate license headers in the generated files.   This is so the license checker doesn't fail.  I could disable generating license headers for generated code, but then the license checker fails because `excludes` option in the checker doesn't work for generated code (since it evaluates which code to exclude first).  Anyways..I plan on finding a strategy for that tomorrow.  This is only a problem for the travis build because it builds with java 8, then runs tests with java 6.

This does not include the changes for scassandra/cql-antlr#3,  I will incorporate those in #171 after this pr is merged.

I also was able to import the commit history from cql-antlr repo into this one.  I didn't even know that was possible, neat!